### PR TITLE
Fix of typo

### DIFF
--- a/src/acceptance-of-delivery/sample.txt
+++ b/src/acceptance-of-delivery/sample.txt
@@ -1,5 +1,5 @@
 Acceptance of Delivery. "Party A" will be deemed to have completed its delivery obligations if in "Party B"'s opinion, the "Widgets" satisfies the Acceptance Criteria, and "Party B" notifies "Party A" in writing that it is accepting the "Widgets".
 
-Inspection and Notice. "Party A" will have 10 Business Days' to inspect and evaluate the "Widgets" on the delivery date before notifying "Party A" that it is either accepting or rejecting the "Widgets".
+Inspection and Notice. "Party B" will have 10 Business Days' to inspect and evaluate the "Widgets" on the delivery date before notifying "Party A" that it is either accepting or rejecting the "Widgets".
 
 Acceptance Criteria. The "Acceptance Criteria" are the specifications the "Widgets" must meet for the "Party A" to comply with its requirements and obligations under this agreement, detailed in "Attachment X", attached to this agreement.


### PR DESCRIPTION
In the context of the initial line in which Party A delivers to Party B, then right of inspection specified in the second paragraph should belong to Party B, not Party A.
Signed-off-by: Brenton B. Miller `brentonbmiller@gmail.com`