### PR TITLE
bump docusign template versions

### DIFF
--- a/src/docusign-connect/package.json
+++ b/src/docusign-connect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "docusign-connect",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Counts events from DocuSign connect with a given envelope status.",
     "license": "Apache-2.0",
     "cicero": {

--- a/src/docusign-po-failure/package.json
+++ b/src/docusign-po-failure/package.json
@@ -1,6 +1,6 @@
 {
     "name": "purchase-order-failure",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "Issues credits for late purchase orders",
     "license": "Apache-2.0",
     "cicero": {


### PR DESCRIPTION
Bumps docusign template versions so they use the new model. I will be putting in a separate PR to update the `docusign-po-failure` logic to use recipient tabs instead of custom envelope fields.

Signed-off-by: Diana Lease <dianarlease@gmail.com>
