### PR TITLE
docs(README): fix coc and slack links - I253

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To save your and our time, we will systematically close all issues that are requ
 support and redirect people to the section you are reading right now.
 
 Other channels for support are:
-- the [Cicero Slack Channel][slack]
+- the [Cicero Slack Channel][apslack]
 
 ### <a name="issue"></a> Found an Issue or Bug?
 
@@ -192,7 +192,7 @@ Accord Project source code files are made available under the [Apache License, V
 
 Accord Project documentation files are made available under the [Creative Commons Attribution 4.0 International License][creativecommons] (CC-BY-4.0).
 
-[coc]: https://github.com/accordproject/docs/blob/master/Accord%20Project%20Code%20of%20Conduct.pdf
+[coc]: https://lfprojects.org/policies/code-of-conduct/
 [apslack]: https://accord-project-slack-signup.herokuapp.com
 [stackoverflow]: http://stackoverflow.com/questions/tagged/cicero
 


### PR DESCRIPTION
# Issue #253 
fixed link to coc and slack in CONTRIBUTING.md

### Changes
- coc links to https://lfprojects.org/policies/code-of-conduct/
- variable for slack channel corrected