### PR TITLE
fix(src): swap buyer and seller - I259

### DIFF
--- a/src/minilatedeliveryandpenalty-capped/grammar/template.tem
+++ b/src/minilatedeliveryandpenalty-capped/grammar/template.tem
@@ -1,7 +1,7 @@
 Late Delivery and Penalty.
 
-In case of delayed delivery of Goods, [{buyer}] shall pay to
-[{seller}] a penalty amounting to [{penaltyPercentage}]% of the total
+In case of delayed delivery of Goods, [{seller}] shall pay to
+[{buyer}] a penalty amounting to [{penaltyPercentage}]% of the total
 value of the Goods for every [{penaltyDuration}] of delay. The total
 amount of penalty shall not, however, exceed [{capPercentage}]% of the
 total value of the delayed goods. If the delay is more than

--- a/src/minilatedeliveryandpenalty-capped/package.json
+++ b/src/minilatedeliveryandpenalty-capped/package.json
@@ -1,7 +1,7 @@
 {
     "name": "minilatedeliveryandpenalty-capped",
     "displayName": "Mini-Late Delivery and Penalty Capped",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "A Late Delivery And Penalty (Mini, Capped)",
     "license": "Apache-2.0",
     "accordproject": {

--- a/src/minilatedeliveryandpenalty-capped/test/logic.feature
+++ b/src/minilatedeliveryandpenalty-capped/test/logic.feature
@@ -6,8 +6,8 @@ Feature: Mini late delivery clause
 """
 Late Delivery and Penalty.
 
-In case of delayed delivery of Goods, "Betty Buyer" shall pay to
-"Steve Seller" a penalty amounting to 10.5% of the total
+In case of delayed delivery of Goods, "Steve Seller" shall pay to
+"Betty Buyer" a penalty amounting to 10.5% of the total
 value of the Goods for every 2 days of delay. The total
 amount of penalty shall not, however, exceed 52% of the
 total value of the delayed goods. If the delay is more than

--- a/src/minilatedeliveryandpenalty-payment/grammar/template.tem
+++ b/src/minilatedeliveryandpenalty-payment/grammar/template.tem
@@ -1,7 +1,7 @@
 Late Delivery and Penalty.
 
-In case of delayed delivery of Goods, [{buyer}] shall pay to
-[{seller}] a penalty amounting to [{penaltyPercentage}]% of the total
+In case of delayed delivery of Goods, [{seller}] shall pay to
+[{buyer}] a penalty amounting to [{penaltyPercentage}]% of the total
 value of the Goods for every [{penaltyDuration}] of delay. The total
 amount of penalty shall not, however, exceed [{capPercentage}]% of the
 total value of the delayed goods. If the delay is more than

--- a/src/minilatedeliveryandpenalty-payment/package.json
+++ b/src/minilatedeliveryandpenalty-payment/package.json
@@ -1,7 +1,7 @@
 {
     "name": "minilatedeliveryandpenalty-payment",
     "displayName": "Mini-Late Delivery and Penalty Payment",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "A Late Delivery And Penalty (Mini, Capped, with Payment)",
     "license": "Apache-2.0",
     "accordproject": {

--- a/src/minilatedeliveryandpenalty-payment/test/logic.feature
+++ b/src/minilatedeliveryandpenalty-payment/test/logic.feature
@@ -6,8 +6,8 @@ Feature: Mini late delivery clause
 """
 Late Delivery and Penalty.
 
-In case of delayed delivery of Goods, "Betty Buyer" shall pay to
-"Steve Seller" a penalty amounting to 10.5% of the total
+In case of delayed delivery of Goods, "Steve Seller" shall pay to
+"Betty Buyer" a penalty amounting to 10.5% of the total
 value of the Goods for every 2 days of delay. The total
 amount of penalty shall not, however, exceed 52% of the
 total value of the delayed goods. If the delay is more than

--- a/src/minilatedeliveryandpenalty/grammar/template.tem
+++ b/src/minilatedeliveryandpenalty/grammar/template.tem
@@ -1,7 +1,7 @@
 Late Delivery and Penalty.
 
-In case of delayed delivery of Goods, [{buyer}] shall pay to
-[{seller}] a penalty amounting to [{penaltyPercentage}]% of the total
+In case of delayed delivery of Goods, [{seller}] shall pay to
+[{buyer}] a penalty amounting to [{penaltyPercentage}]% of the total
 value of the Goods for every [{penaltyDuration}] of delay. If the
 delay is more than [{maximumDelay}], the Buyer is entitled to
 terminate this Contract.

--- a/src/minilatedeliveryandpenalty/package.json
+++ b/src/minilatedeliveryandpenalty/package.json
@@ -1,7 +1,7 @@
 {
     "name": "minilatedeliveryandpenalty",
     "displayName": "Mini-Late Delivery and Penalty",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "description": "A Late Delivery And Penalty Clause (Mini).",
     "license": "Apache-2.0",
     "accordproject": {

--- a/src/minilatedeliveryandpenalty/test/logic.feature
+++ b/src/minilatedeliveryandpenalty/test/logic.feature
@@ -6,8 +6,8 @@ Feature: Mini late delivery clause
 """
 Late Delivery and Penalty.
 
-In case of delayed delivery of Goods, "Betty Buyer" shall pay to
-"Steve Seller" a penalty amounting to 10.5% of the total
+In case of delayed delivery of Goods, "Steve Seller" shall pay to
+"Betty Buyer" a penalty amounting to 10.5% of the total
 value of the Goods for every 2 days of delay. If the
 delay is more than 15 days, the Buyer is entitled to
 terminate this Contract.


### PR DESCRIPTION
# Issue #259 
This addresses a bug where the buyer and seller are swapped.

### Changes
- Swap the buyer and seller tags so that the seller pays the buyer.
  - minilatedelivery, minilatedelivery-capped and minilatedelivery-payment updated

### Flags
none
### Related Issues
- Issue #259 
- Pull Request #260 