### PR TITLE
#144 Version Dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "build": "node run.js",
     "test": "lerna run test",
-    "generate": "SKIP_TESTS=true node run.js"
+    "generate": "SKIP_TESTS=true node run.js",
+    "update-html-dropdowns": "UPDATE_DROPDOWNS=true node run.js"
   },
   "nyc": {
     "include": [
@@ -31,6 +32,8 @@
     "chai-as-promised": "7.1.1",
     "chai-things": "0.2.0",
     "fs-extra": "^6.0.1",
+    "jquery": "^3.4.1",
+    "jsdom": "^15.1.1",
     "lodash": "^4.17.11",
     "mocha": "5.2.0",
     "moment": "^2.22.2",

--- a/views/dropdown.njk
+++ b/views/dropdown.njk
@@ -1,4 +1,4 @@
-{% for name in templateVersions |sort(true)%}
+{% for name in templateVersions %}
   <a href="{{name}}.html" class="dropdown-item {{"is-active" if name === identifier}}">
       {{name}}
   </a>

--- a/views/dropdown.njk
+++ b/views/dropdown.njk
@@ -1,0 +1,5 @@
+{% for name in templateVersions |sort(true)%}
+  <a href="{{name}}.html" class="dropdown-item {{"is-active" if name === identifier}}">
+      {{name}}
+  </a>
+{% endfor %}


### PR DESCRIPTION
Signed-off-by: Vladimir Tasic <vladimir.tasik@gmail.com>

# Issue #144
Use jsdom and jquery to change the `.dropdown-content` child elements so that all versions are present in every version dropdown list.
It does not touch files where the `.dropdown-content` class is absent, so first versions are not modified.

Someone will have to commit the modified `*html` files

### Changes
- Add new command-line option in package.json
  - `npm run update-html-dropdowns`
  - run only if old template is generated and `.dropdown-content` class is found in the file
  - Add an environment variable `UPDATE_DROPDOWNS`
