### PR TITLE
docs(*): update markdown files and fix typos - I257

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -31,21 +31,21 @@ f. The TSC may elect a TSC Chair, who will preside over meetings of the TSC and 
 
 g. Responsibilities: The TSC will be responsible for all aspects of oversight relating to the Project, which may include:
 
-i. Coordinating the technical direction of the Project;
+i. coordinating the technical direction of the Project;
 
-ii. Approving, modifying and disbanding Working Groups and sub-projects;
+ii. approving, modifying and disbanding Working Groups and sub-projects;
 
-iii. Creating sub-committees to focus on cross-project issues and requirements;
+iii. creating sub-committees to focus on cross-project issues and requirements;
 
-iv. Appointing representatives to work with other open source or open standards communities;
+iv. appointing representatives to work with other open source or open standards communities;
 
-v. Establishing meeting procedures, community norms, workflows, issuing releases, and security issue reporting policies;
+v. establishing meeting procedures, community norms, workflows, issuing releases, and security issue reporting policies;
 
-vi. Approving and implementing policies and processes for contributing (to be published in the CONTRIBUTING file) and coordinating with the series manager of the Project (as provided for in the Series Agreement, the “Series Manager”) to resolve matters or concerns that may arise as set forth in Section 7 of this Charter;
+vi. approving and implementing policies and processes for contributing (to be published in the CONTRIBUTING file) and coordinating with the series manager of the Project (as provided for in the Series Agreement, the “Series Manager”) to resolve matters or concerns that may arise as set forth in Section 7 of this Charter;
 
-vii. Discussions, seeking consensus, and where necessary, voting on technical matters relating to the code base that affect multiple projects; and
+vii. discussions, seeking consensus, and where necessary, voting on technical matters relating to the code base that affect multiple projects; and
 
-viii. Coordinating any marketing, events, or communications regarding the Project.
+viii.coordinating any marketing, events, or communications regarding the Project.
 
 ## 3. TSC Voting
 a. While the Project aims to operate as a consensus-based community, if any TSC decision requires a vote to move the Project forward, the voting members of the TSC will vote on a one vote per voting member basis.
@@ -57,7 +57,7 @@ c. Except as provided in Section 7.c. and 8.a, decisions by vote at a meeting re
 d. In the event a vote cannot be resolved by the TSC, any voting member of the TSC may refer the matter to the Series Manager for assistance in reaching a resolution.
 
 ## 4. Compliance with Policies
-a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Projects. Contributors will comply with the policies of LF Projects as may be adopted and amended by LF Projects, including, without limitation [the policies listed here](https://lfprojects.org/policies/).
+a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Projects. Contributors will comply with the policies of LF Projects as may be adopted and amended by LF Projects, including, without limitation the policies listed at https://lfprojects.org/policies/.
 
 b. The TSC may adopt a Code of Conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. In the event that a Project-specific CoC has not been approved, the [LF Projects Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) will apply for all Collaborators in the Project.
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -31,21 +31,21 @@ f. The TSC may elect a TSC Chair, who will preside over meetings of the TSC and 
 
 g. Responsibilities: The TSC will be responsible for all aspects of oversight relating to the Project, which may include:
 
-i. coordinating the technical direction of the Project;
+i. Coordinating the technical direction of the Project;
 
-ii. approving, modifying and disbanding Working Groups and sub-projects;
+ii. Approving, modifying and disbanding Working Groups and sub-projects;
 
-iii. creating sub-committees to focus on cross-project issues and requirements;
+iii. Creating sub-committees to focus on cross-project issues and requirements;
 
-iv. appointing representatives to work with other open source or open standards communities;
+iv. Appointing representatives to work with other open source or open standards communities;
 
-v. establishing meeting procedures, community norms, workflows, issuing releases, and security issue reporting policies;
+v. Establishing meeting procedures, community norms, workflows, issuing releases, and security issue reporting policies;
 
-vi. approving and implementing policies and processes for contributing (to be published in the CONTRIBUTING file) and coordinating with the series manager of the Project (as provided for in the Series Agreement, the “Series Manager”) to resolve matters or concerns that may arise as set forth in Section 7 of this Charter;
+vi. Approving and implementing policies and processes for contributing (to be published in the CONTRIBUTING file) and coordinating with the series manager of the Project (as provided for in the Series Agreement, the “Series Manager”) to resolve matters or concerns that may arise as set forth in Section 7 of this Charter;
 
-vii. discussions, seeking consensus, and where necessary, voting on technical matters relating to the code base that affect multiple projects; and
+vii. Discussions, seeking consensus, and where necessary, voting on technical matters relating to the code base that affect multiple projects; and
 
-viii.coordinating any marketing, events, or communications regarding the Project.
+viii. Coordinating any marketing, events, or communications regarding the Project.
 
 ## 3. TSC Voting
 a. While the Project aims to operate as a consensus-based community, if any TSC decision requires a vote to move the Project forward, the voting members of the TSC will vote on a one vote per voting member basis.
@@ -57,9 +57,9 @@ c. Except as provided in Section 7.c. and 8.a, decisions by vote at a meeting re
 d. In the event a vote cannot be resolved by the TSC, any voting member of the TSC may refer the matter to the Series Manager for assistance in reaching a resolution.
 
 ## 4. Compliance with Policies
-a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Projects. Contributors will comply with the policies of LF Projects as may be adopted and amended by LF Projects, including, without limitation the policies listed at https://lfprojects.org/policies/.
+a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Projects. Contributors will comply with the policies of LF Projects as may be adopted and amended by LF Projects, including, without limitation [the policies listed here](https://lfprojects.org/policies/).
 
-b. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. In the event that a Project-specific CoC has not been approved, the LF Projects Code of Conduct listed at https://lfprojects.org/policies will apply for all Collaborators in the Project.
+b. The TSC may adopt a Code of Conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. In the event that a Project-specific CoC has not been approved, the [LF Projects Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) will apply for all Collaborators in the Project.
 
 c. When amending or adopting any policy applicable to the Project, LF Projects will publish such policy, as to be amended or adopted, on its web site at least 30 days prior to such policy taking effect; provided, however, that in the case of any amendment of the Trademark Policy or Terms of Use of LF Projects, any such amendment is effective upon publication on LF Project’s web site.
 
@@ -77,16 +77,16 @@ c. Under no circumstances will LF Projects be expected or required to undertake 
 ## 6. General Rules and Operations.
 a. The Project will:
 
-i. engage in the work of the Project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Projects, LFP, Inc. and other partner organizations in the open source community; and
+i. Engage in the work of the Project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Projects, LFP, Inc. and other partner organizations in the open source community; and
 
-ii. respect the rights of all trademark owners, including any branding and trademark usage guidelines.
+ii. Respect the rights of all trademark owners, including any branding and trademark usage guidelines.
 
 ## 7. Intellectual Property Policy
 a. Collaborators acknowledge that the copyright in all new contributions will be retained by the copyright holder as independent works of authorship and that no contributor or copyright holder will be required to assign copyrights to the Project.
 
 b. Except as described in Section 7.c., all contributions to the Project are subject to the following:
 
-i. All new inbound code contributions to the Project must be made using the Apache License, Version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0 (the “Project License”).
+i. All new inbound code contributions to the Project must be made using the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) (the “Project License”).
 
 ii. All new inbound code contributions must also be accompanied by a [Developer Certificate of Origin](http://developercertificate.org) sign-off in the source code system that is submitted through a TSC-approved contribution process which will bind the authorized contributor and, if not self-employed, their employer to the applicable license;
 

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -59,7 +59,7 @@ d. In the event a vote cannot be resolved by the TSC, any voting member of the T
 ## 4. Compliance with Policies
 a. This Charter is subject to the Series Agreement for the Project and the Operating Agreement of LF Projects. Contributors will comply with the policies of LF Projects as may be adopted and amended by LF Projects, including, without limitation the policies listed at https://lfprojects.org/policies/.
 
-b. The TSC may adopt a Code of Conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. In the event that a Project-specific CoC has not been approved, the [LF Projects Code of Conduct](https://lfprojects.org/policies/code-of-conduct/) will apply for all Collaborators in the Project.
+b. The TSC may adopt a code of conduct (“CoC”) for the Project, which is subject to approval by the Series Manager. In the event that a Project-specific CoC has not been approved, the LF Projects Code of Conduct listed at https://lfprojects.org/policies will apply for all Collaborators in the Project.
 
 c. When amending or adopting any policy applicable to the Project, LF Projects will publish such policy, as to be amended or adopted, on its web site at least 30 days prior to such policy taking effect; provided, however, that in the case of any amendment of the Trademark Policy or Terms of Use of LF Projects, any such amendment is effective upon publication on LF Project’s web site.
 
@@ -77,16 +77,16 @@ c. Under no circumstances will LF Projects be expected or required to undertake 
 ## 6. General Rules and Operations.
 a. The Project will:
 
-i. Engage in the work of the Project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Projects, LFP, Inc. and other partner organizations in the open source community; and
+i. engage in the work of the Project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of LF Projects, LFP, Inc. and other partner organizations in the open source community; and
 
-ii. Respect the rights of all trademark owners, including any branding and trademark usage guidelines.
+ii. respect the rights of all trademark owners, including any branding and trademark usage guidelines.
 
 ## 7. Intellectual Property Policy
 a. Collaborators acknowledge that the copyright in all new contributions will be retained by the copyright holder as independent works of authorship and that no contributor or copyright holder will be required to assign copyrights to the Project.
 
 b. Except as described in Section 7.c., all contributions to the Project are subject to the following:
 
-i. All new inbound code contributions to the Project must be made using the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0) (the “Project License”).
+i. All new inbound code contributions to the Project must be made using the Apache License, Version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0 (the “Project License”).
 
 ii. All new inbound code contributions must also be accompanied by a [Developer Certificate of Origin](http://developercertificate.org) sign-off in the source code system that is submitted through a TSC-approved contribution process which will bind the authorized contributor and, if not self-employed, their employer to the applicable license;
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Cicero Template Library
 
-> Thanks to the angularJS team for the bulk of this text!
+> Thanks to the AngularJS team for the bulk of this text!
 
 We'd love for you to contribute to a template to make the Accord Project template library even better than it is today! Here are the guidelines we'd like you to follow:
 
@@ -46,7 +46,7 @@ If you find a bug in the documentation, you can help us by submitting an issue t
 
 ### <a name="feature"></a> Missing a Feature?
 
-You can request a new feature by submitting an issue to our [GitHub Repository][github-issues].
+You can request a new feature by [submitting an issue][github-issues] to our GitHub Repository.
 
 If you would like to implement a new feature then consider what kind of change it is:
 
@@ -54,7 +54,7 @@ If you would like to implement a new feature then consider what kind of change i
   [GitHub issue][github-issues] that clearly outlines the changes and benefits of the feature.
 * **Small Changes** can directly be crafted and submitted to the [GitHub Repository][github]
   as a Pull Request. See the section about [Pull Request Submission Guidelines][contribute.submitpr], and
-  for detailed information the [core development documentation][developers].
+  for detailed information read the [core development documentation][developers].
 
 ### <a name="docs"></a> Want a Doc Fix?
 
@@ -90,8 +90,8 @@ make it easier to understand and categorize the issue.
 Before you submit your pull request consider the following guidelines:
 
 * Ensure there is an open [Issue][github-issues] for what you will be working on. If there is not, open one up by going through [these guidelines][contribute.submit].
-* Search [GitHub][pulls] for an open or closed Pull Request that relates to your submission. You don't want to duplicate effort.
-* Create the [development environment][developers.setup]
+* Search for an open or closed [Pull Request][pulls] that relates to your submission. You don't want to duplicate effort.
+* Create the [development environment][developers.setup].
 * Make your changes in a new git branch: cicero-template-library
 
   ```text
@@ -108,7 +108,7 @@ Before you submit your pull request consider the following guidelines:
 * Follow our [Coding Rules][developers.rules].
 * Ensure you provide a DCO sign-off for your commits using the -s option of git commit. For more information see [how this works][dcohow].
 * If the changes affect public APIs, change or add relevant [documentation][developers.documentation].
-* Run the [unit][developers.unit-tests] test suite, and ensure that all tests pass.
+* Run the [unit test suite][developers.unit-tests], and ensure that all tests pass.
 
 * Commit your changes using a descriptive commit message that follows our [commit message conventions][developers.commits]. Adherence to the [commit message conventions][developers.commits] is required because release notes are automatically generated from these messages.
 
@@ -118,7 +118,7 @@ Before you submit your pull request consider the following guidelines:
 
   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
 
-* Before creating the Pull Request, ensure your branch sits on top of master (as opposed to branch off a branch). This ensures the reviewer will need only minimal effort to integrate your work by fast-fowarding master:
+* Before creating the Pull Request, ensure your branch sits on top of master (as opposed to branch off a branch). This ensures the reviewer will need only minimal effort to integrate your work by fast-forwarding master:
 
   ```text
     git rebase upstream/master

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -59,7 +59,7 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 
 * All features or bug fixes **must be tested** by one or more [specs][developers.unit-tests].
 * All public API methods **must be documented** with jsdoc. To see how we document our APIs, please check
-  out the existing source code and see the section about [writing documentation][developers.documentation]
+  out the existing source code and see the section about [writing documentation][developers.documentation].
 * With the exceptions listed below, we follow the rules contained in
   [Google's JavaScript Style Guide][google].
 
@@ -114,7 +114,7 @@ The subject contains succinct description of the change:
 * no dot (.) at the end
 
 ### Footer
-The footer should contain [reference GitHub Issues that this commit addresses][github-issues].
+The footer should contain [reference GitHub Issues][github-issues] that this commit addresses.
 
 ## <a name="pullrequests"></a> GitHub Pull Request Guidelines
 Pull Requests should consist of a complete addition to the code which contains value. 

--- a/README.md
+++ b/README.md
@@ -329,5 +329,5 @@ Accord Project documentation files are made available under the [Creative Common
 [contributing]: https://github.com/accordproject/cicero-template-library/blob/master/CONTRIBUTING.md
 [developers]: https://github.com/accordproject/cicero-template-library/blob/master/DEVELOPERS.md
 
-[apache]: https://github.com/accordproject/template-studio-v2/blob/master/LICENSE
+[apache]: https://github.com/accordproject/cicero-template-library/blob/master/LICENSE
 [creativecommons]: http://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Signed-off-by: Michael Zhou <myz227@nyu.edu>

# Issue #257 
<OVERALL SUMMARY OF PULL REQUEST>
Updated markdown files by correcting for incorrect markdown links, integrating existing links into new markdown, and ensuring consistency in markdown style. Also fixes typos, grammar, and punctuation errors in documentation. All tests confirmed to pass.

### Changes
- Corrected wrong markdown link for Code of Conduct in `CHARTER.md`
  - Added `/code-of-conduct/` to end of existing markdown link
- Replaced in-text URLs with appropriate markdown to eliminate visibility from documentation
- Capitalized first letter for numbered bullet points to stay consistent with style
- Modified markdown to be more appropriate with content of associated links