### PR TITLE
fix(acceptance-of-delivery): remove unnecessary the

### DIFF
--- a/src/acceptance-of-delivery/text/grammar.tem.md
+++ b/src/acceptance-of-delivery/text/grammar.tem.md
@@ -15,6 +15,6 @@ evaluate the {{deliverable}} on the delivery date before notifying
 ## Acceptance Criteria.
 
 The "Acceptance Criteria" are the specifications the {{deliverable}}
-must meet for the {{shipper}} to comply with its requirements and
+must meet for {{shipper}} to comply with its requirements and
 obligations under this agreement, detailed in {{attachment}}, attached
 to this agreement.

--- a/src/acceptance-of-delivery/text/sample.md
+++ b/src/acceptance-of-delivery/text/sample.md
@@ -15,6 +15,6 @@ evaluate the "Widgets" on the delivery date before notifying
 ## Acceptance Criteria.
 
 The "Acceptance Criteria" are the specifications the "Widgets"
-must meet for the "Party A" to comply with its requirements and
+must meet for "Party A" to comply with its requirements and
 obligations under this agreement, detailed in "Attachment X", attached
 to this agreement.


### PR DESCRIPTION
# No Issue
I just fixed a typo in this clause so that when inputting the name of Party A it was not preceded by "the."