### PR TITLE
fix(template) odd 'the' removed from acceptance of delivery template

### DIFF
--- a/src/acceptance-of-delivery/package.json
+++ b/src/acceptance-of-delivery/package.json
@@ -1,7 +1,7 @@
 {
     "name": "acceptance-of-delivery",
     "displayName": "Acceptance of Delivery",
-    "version": "0.14.0",
+    "version": "0.14.1",
     "description": "This clause allows the receiver of goods to inspect them for a given time period after delivery.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/acceptance-of-delivery/test/logic.feature
+++ b/src/acceptance-of-delivery/test/logic.feature
@@ -21,7 +21,7 @@ evaluate the "Widgets" on the delivery date before notifying
 ## Acceptance Criteria.
 
 The "Acceptance Criteria" are the specifications the "Widgets"
-must meet for the "Party A" to comply with its requirements and
+must meet for "Party A" to comply with its requirements and
 obligations under this agreement, detailed in "Attachment X", attached
 to this agreement.
 """

--- a/src/acceptance-of-delivery/text/grammar.tem.md
+++ b/src/acceptance-of-delivery/text/grammar.tem.md
@@ -15,6 +15,6 @@ evaluate the {{deliverable}} on the delivery date before notifying
 ## Acceptance Criteria.
 
 The "Acceptance Criteria" are the specifications the {{deliverable}}
-must meet for the {{shipper}} to comply with its requirements and
+must meet for {{shipper}} to comply with its requirements and
 obligations under this agreement, detailed in {{attachment}}, attached
 to this agreement.

--- a/src/acceptance-of-delivery/text/sample.md
+++ b/src/acceptance-of-delivery/text/sample.md
@@ -15,6 +15,6 @@ evaluate the "Widgets" on the delivery date before notifying
 ## Acceptance Criteria.
 
 The "Acceptance Criteria" are the specifications the "Widgets"
-must meet for the "Party A" to comply with its requirements and
+must meet for "Party A" to comply with its requirements and
 obligations under this agreement, detailed in "Attachment X", attached
 to this agreement.


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Why

Writing template text is a delicate art. A suggestion was made in #355 to remove "the" in the third paragraph to improve readability. This seems like a valid change but the aforementioned PR hasn't been completed so I'm creating a new one.

### Changes

- Remove `the` in the third paragraph in the acceptance of delivery template before `{{shipper}}` to improve readability
- Bump up version (should those text changes be considered a patch or minor update?)

