### PR TITLE
chore(CI) Remove npm build which would build the archives!

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
     
       - run: npm ci
-      - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
Signed-off-by: Jerome Simeon <jeromesimeon@me.com>

### Changes

- Removing `npm build` step in GitHub workflow

### Why

We really don't want to build the archives on every PR!

