### PR TITLE
Fix URL version issue for docusign-connect template

### DIFF
--- a/src/docusign-connect/package.json
+++ b/src/docusign-connect/package.json
@@ -1,7 +1,7 @@
 {
     "name": "docusign-connect",
     "displayName": "Docusign Connect",
-    "version": "0.10.0",
+    "version": "0.9.0",
     "description": "Counts events from DocuSign connect with a given envelope status.",
     "author": "Accord Project",
     "license": "Apache-2.0",


### PR DESCRIPTION
Closes #390
<!--- Provide an overall summary of the pull request -->
This pull request fixes the invalid link for the docusign-connect template on the Accord Project Template Studio home page.

Changes
<!--- More detailed and granular description of changes -->
Updated the docusign-connect link in package.json to reference version 0.9.0 instead of 0.10.0.
Ensured that the correct link is now functional and redirects properly.
Flags
<!--- Provide context or concerns a reviewer should be aware of -->
Verified functionality of the updated link in the Template Studio environment.
Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->
No screenshots applicable as this is a backend link update.

Related Issues
Issue #390


