### PR TITLE
feat: add tabs for viewing templates by type

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,7 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches: 
-      - master
+      - main
 
 jobs:
 
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout code
@@ -28,15 +28,15 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: NPM Install
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: npm install
 
       - name: NPM Build
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: npm run build
 
       - name: Set S3 
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: |
             echo "AWS_S3_BUCKET=${{secrets.AWS_S3_BUCKET}}" >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
-          - 14.x
+          - 20.x
+          - 20.x
         os:
           - ubuntu-latest
           - windows-latest

--- a/run.js
+++ b/run.js
@@ -115,13 +115,17 @@ nunjucks.configure('./views', {
             });
             await writeFile('./build/index.html', templateResult);
 
-            // generate the contracts-only html page
             const contractsOnly = {};
+            const clausesOnly = {};
             Object.keys(latestIndex).forEach(key => {
                 if (latestIndex[key].type === 0) {
                     contractsOnly[key] = latestIndex[key];
+                } else {
+                    clausesOnly[key] = latestIndex[key];
                 }
             });
+
+            // generate the contracts-only html page
             const contractsResult = nunjucks.render('index.njk', {
                 serverRoot: serverRoot,
                 templateIndex: contractsOnly,
@@ -130,7 +134,6 @@ nunjucks.configure('./views', {
             await writeFile('./build/contracts.html', contractsResult);
 
             // generate the clause-only html page
-            const clausesOnly = {};
             Object.keys(latestIndex).forEach(key => {
                 if (latestIndex[key].type !== 0) {
                     clausesOnly[key] = latestIndex[key];

--- a/run.js
+++ b/run.js
@@ -114,6 +114,34 @@ nunjucks.configure('./views', {
                 templateIndex: latestIndex,
             });
             await writeFile('./build/index.html', templateResult);
+
+            // generate the contracts-only html page
+            const contractsOnly = {};
+            Object.keys(latestIndex).forEach(key => {
+                if (latestIndex[key].type === 0) {
+                    contractsOnly[key] = latestIndex[key];
+                }
+            });
+            const contractsResult = nunjucks.render('index.njk', {
+                serverRoot: serverRoot,
+                templateIndex: contractsOnly,
+                filterType: 'contract'
+            });
+            await writeFile('./build/contracts.html', contractsResult);
+
+            // generate the clause-only html page
+            const clausesOnly = {};
+            Object.keys(latestIndex).forEach(key => {
+                if (latestIndex[key].type !== 0) {
+                    clausesOnly[key] = latestIndex[key];
+                }
+            });
+            const clausesResult = nunjucks.render('index.njk', {
+                serverRoot: serverRoot,
+                templateIndex: clausesOnly,
+                filterType: 'clause'
+            });
+            await writeFile('./build/clauses.html', clausesResult);
         }
     }
     catch(err) {

--- a/views/index.njk
+++ b/views/index.njk
@@ -16,7 +16,26 @@
 
     <section class="section">
         <div class="container">
-            <h2 class="title is-2">Templates</h2>
+            <div class="level">
+              <div class="level-left">
+                <h2 class="title is-2">Templates</h2>
+              </div>
+              <div class="level-right">
+                <div class="tabs is-toggle is-small">
+                  <ul>
+                    <li {% if filterType == 'all' %}class="is-active"{% endif %}>
+                      <a href="index.html">All</a>
+                    </li>
+                    <li {% if filterType == 'contract' %}class="is-active"{% endif %}>
+                      <a href="contracts.html">Contracts</a>
+                    </li>
+                    <li {% if filterType == 'clause' %}class="is-active"{% endif %}>
+                      <a href="clauses.html">Clauses</a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
             <table class="table box versions">
             <thead>
                 <tr>


### PR DESCRIPTION
<!--- Provide a formatted commit message describing this PR in the Title above -->
<!--- See our DEVELOPERS guide below: -->
<!--- https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format -->
# Closes #435 <CORRESPONDING ISSUE NUMBER>
<!--- Provide an overall summary of the pull request -->
This Pull Request added navigation tabs to allow users to filter and view templates by type: All, Contracts, or Clauses.

### Changes
<!--- More detailed and granular description of changes -->
<!--- These should likely be gathered from commit message summaries -->
- <ONE> Updated the `index.njk` file to include a navigation bar for easy filtering by template type.
- <TWO> Added logic in `run.js` to filter templates by type and generate separate pages: contracts.html, and clauses.html.
- <THREE>  Updated `node-versions` used in the CI process.
- <Four> Changed from `master` to `main` in the workflow configuration.

### Flags
<!--- Provide context or concerns a reviewer should be aware of -->
Not Applicable.

### Screenshots or Video
<!--- Provide an easily accessible demonstration of the changes, if applicable -->

![Screenshot](https://github.com/user-attachments/assets/3330282a-00a5-4ef8-8f68-4acb45a72ed9)

![Screenshot](https://github.com/user-attachments/assets/6679ce59-1f8a-4440-99b5-d8f9d378741c)

### Related Issues
- Issue #435

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary
- [x] Merging to `master` from `fork:branchname`
