### PR TITLE
Update footer copyright year to 2018-2025

### DIFF
--- a/views/page.njk
+++ b/views/page.njk
@@ -215,7 +215,7 @@
                 </a>
               </div>
                 <p>
-                    Copyright 2018-2019 <a href="https://accordproject.org">Accord Project</a>. Licensed under the
+                    Copyright © 2018-2025 <a href="https://accordproject.org">Accord Project</a>. Licensed under the
                     <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache-2.0</a> Open Source software license.
                 </p>
             </div>


### PR DESCRIPTION
# Closes #404

### Changes
- Updated footer copyright year in `views/page.njk`
- Set range from `2018-2019` to `2018-2025`, consistent with documentation site

### Flags
- No functional or UI-breaking changes
- Build and preview verified locally

### Screenshots
Updated footer as rendered locally:

<img width="1887" height="962" alt="Screenshot (1518)" src="https://github.com/user-attachments/assets/eca666cd-c8c8-4f31-8dbf-51d7d4b3b306" />

### Related Issues
- Issue #404

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests (N/A — static content update)
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [ ] Extend the documentation, if necessary (N/A)
- [x] Merging to `master` from `fork:fix-footer-copyright-year`
