### PR TITLE
fix(supply-agreement-loc): correct template variable syntax typo

### DIFF
--- a/src/supply-agreement-loc/text/grammar.tem.md
+++ b/src/supply-agreement-loc/text/grammar.tem.md
@@ -82,7 +82,7 @@ This SUPPLY AGREEMENT (together with all schedules attached hereto, the “Agree
    2. Use Solely for Purpose. A receiving party may only use the Confidential Information according to the terms of this agreement.
    3. Non-Disclosure. The {{importer}} may not disclose Confidential Information to any third party, except to the extent
       1. permitted by this agreement,
-      2. the {[exporter}} consents in writing, or
+      2. the {{exporter}} consents in writing, or
       3. required by Law.
    4. Notice. The {{importer}} shall notify the {{exporter}} if it
       1. is required by Law to disclose any Confidential Information, or

--- a/src/supply-agreement-loc/text/sample.md
+++ b/src/supply-agreement-loc/text/sample.md
@@ -82,7 +82,7 @@ This SUPPLY AGREEMENT (together with all schedules attached hereto, the “Agree
    2. Use Solely for Purpose. A receiving party may only use the Confidential Information according to the terms of this agreement.
    3. Non-Disclosure. The "Dan's Imports" may not disclose Confidential Information to any third party, except to the extent
       1. permitted by this agreement,
-      2. the {[exporter}} consents in writing, or
+      2. the "Acme Exports" consents in writing, or
       3. required by Law.
    4. Notice. The "Dan's Imports" shall notify the "Acme Exports" if it
       1. is required by Law to disclose any Confidential Information, or


### PR DESCRIPTION
Fix typo in line 85 where `{[exporter}}` was used instead of `{{exporter}}` in grammar.tem.md, and the corresponding sample value in sample.md.

# Closes #393

A typo in the `supply-agreement-loc` template was causing invalid template syntax. The opening brace for the `exporter` variable was incorrectly written as `{[` instead of `{{`.

### Changes
- Fixed `{[exporter}}` → `{{exporter}}` in [src/supply-agreement-loc/text/grammar.tem.md](cci:7://file:///home/shubhraj/OpenSource/cicero-template-library/src/supply-agreement-loc/text/grammar.tem.md:0:0-0:0) on line 85
- Fixed `{[exporter}}` → `"Acme Exports"` in [src/supply-agreement-loc/text/sample.md](cci:7://file:///home/shubhraj/OpenSource/cicero-template-library/src/supply-agreement-loc/text/sample.md:0:0-0:0) on line 85

### Flags
- Minimal change - only 2 characters modified in grammar template
- No functional changes to template logic

### Screenshots or Video
N/A - Text-only typo fix

### Related Issues
- Issue #393

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests (N/A - typo fix only)
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary (N/A)
- [x] Merging to `master` from `Shubh-Raj:fix/supply-agreement-loc-typo`