### PR TITLE
fix(readme): replace broken travis ci badge with github actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </h1>
 
 <p align="center">
-  <a href="https://travis-ci.org/accordproject/cicero-template-library">
-    <img src="https://travis-ci.org/accordproject/cicero-template-library.svg" alt="Build Status"/>
+  <a href="https://github.com/accordproject/cicero-template-library/actions/workflows/build.yml">
+    <img src="https://github.com/accordproject/cicero-template-library/actions/workflows/build.yml/badge.svg" alt="Build Status"/>
   </a>
   <a href="https://github.com/accordproject/cicero-template-library/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/accordproject/cicero-template-library" alt="GitHub license"/>


### PR DESCRIPTION
# Closes
<!--- No related issue, minor doc fix -->

<!--- Provide an overall summary of the pull request -->
This PR replaces the deprecated (and broken) Travis CI badge in the README with the current GitHub Actions build status badge.

### Changes
<!--- More detailed and granular description of changes -->
- Updated [README.md](cci:7://file:///c:/Users/Lenovo/template-playground/README.md:0:0-0:0) to point to the [build.yml](cci:7://file:///c:/Users/Lenovo/cicero-template-library/.github/workflows/build.yml:0:0-0:0) workflow on GitHub Actions instead of `travis-ci.org`.

### ScreenShots
**BEFORE**

<img width="1117" height="666" alt="Screenshot 2026-01-12 124300" src="https://github.com/user-attachments/assets/cdebfce3-f626-4c92-b9c8-d758b388c926" />

**AFTER**

<img width="1250" height="592" alt="Screenshot 2026-01-12 124342" src="https://github.com/user-attachments/assets/b76f015c-c3b8-4856-a320-370624e39e49" />

### Flags
- None

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Merging to `main` from `fork:Rahul-R79/fix-readme-badge`