### PR TITLE
feat(website): add dark mode toggle

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,16 +1,52 @@
+/* CSS Custom Properties for Theme Support */
+:root {
+	--bg-primary: #ffffff;
+	--bg-secondary: #f5f5f5;
+	--bg-dark: rgb(27, 37, 64);
+	--text-primary: rgb(27, 37, 64);
+	--text-secondary: rgba(5, 12, 64, 0.7);
+	--text-muted: rgba(5, 12, 64, 0.502);
+	--accent-color: rgb(25, 198, 199);
+	--link-hover: rgb(27, 37, 64);
+	--border-color: rgb(219, 219, 219);
+	--box-bg: #ffffff;
+	--box-shadow: 0 0.5em 1em -0.125em rgba(10,10,10,.1), 0 0 0 1px rgba(10,10,10,.02);
+	--table-bg: #ffffff;
+	--code-bg: #f5f5f5;
+}
+
+[data-theme="dark"] {
+	--bg-primary: #1a1a2e;
+	--bg-secondary: #16213e;
+	--bg-dark: #0f0f1a;
+	--text-primary: #e8e8e8;
+	--text-secondary: rgba(232, 232, 232, 0.8);
+	--text-muted: rgba(232, 232, 232, 0.6);
+	--accent-color: rgb(25, 198, 199);
+	--link-hover: #ffffff;
+	--border-color: rgba(255, 255, 255, 0.1);
+	--box-bg: #16213e;
+	--box-shadow: 0 0.5em 1em -0.125em rgba(0,0,0,.3), 0 0 0 1px rgba(255,255,255,.05);
+	--table-bg: #16213e;
+	--code-bg: #0f0f1a;
+}
+
 /* Global Styles Override */
 body {
 	font-family: "Graphik", sans-serif, Arial, Helvetica, sans-serif !important;
+	background-color: var(--bg-primary);
+	color: var(--text-primary);
+	transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 a {
-	color: rgb(25, 198, 199);
+	color: var(--accent-color);
 	font-weight: 500;
 	transition: color 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 a:hover {
-	color: rgb(27, 37, 64);
+	color: var(--link-hover);
 }
 
 .content h1,
@@ -19,7 +55,7 @@ a:hover {
 .content h4,
 .content h5,
 .content h6 {
-	color: rgb(27, 37, 64);
+	color: var(--text-primary);
 }
 
 .content h1:not(:first-child) {
@@ -42,7 +78,7 @@ a:hover {
 	font-size: 15px;
 	font-weight: 400;
 	line-height: 28px;
-	color: rgba(5, 12, 64, 0.7);
+	color: var(--text-secondary);
 }
 
 .content pre {
@@ -61,14 +97,16 @@ pre {
 	border-radius: 10px;
 	display: inline-block;
 	margin-bottom: 50px !important;
-  padding: 2.25rem;
+	padding: 2.25rem;
+	background-color: var(--box-bg);
+	box-shadow: var(--box-shadow);
 }
 
 /* Headings */
 
 .title {
 	font-weight: 400;
-	color: rgb(27, 37, 64);
+	color: var(--text-primary);
 }
 
 .title:not(:last-child) {
@@ -100,7 +138,7 @@ pre {
 	font-size: 15px;
 	font-weight: 400;
 	line-height: 28px;
-	color: rgba(5, 12, 64, 0.7);
+	color: var(--text-secondary);
 }
 
 .logo.box {
@@ -269,46 +307,40 @@ svg.svg-inline--fa.fa-angle-down.fa-w-10 path {
 
 .table thead th {
 	font-weight: 500;
-	color: rgb(5, 12, 64);
+	color: var(--text-muted);
 	line-height: initial;
-	border-bottom: 2px solid rgba(5, 12, 64, 0.102);
-	color: rgba(5, 12, 64, 0.502);
+	border-bottom: 2px solid var(--border-color);
 	font-size: 0.6666666667rem;
-	font-weight: 500;
 	letter-spacing: 2.7px;
-	line-height: initial;
 	text-transform: uppercase;
 	padding-bottom: 15px;
 }
 
 .table td,
 .table th {
-	border: 1px solid rgb(219, 219, 219);
+	border: 1px solid var(--border-color);
 	border-width: 0 0 1px;
 	padding: 0.5em 0.75em;
 	vertical-align: top;
-	color: rgba(5, 12, 64, 0.7);
+	color: var(--text-secondary);
 	font-size: 15px;
 	font-weight: 400;
 }
 
 .table tfoot th {
 	font-weight: 500;
-	color: rgb(5, 12, 64);
+	color: var(--text-muted);
 	line-height: initial;
-	border-top: 2px solid rgba(5, 12, 64, 0.102);
-	color: rgba(5, 12, 64, 0.502);
+	border-top: 2px solid var(--border-color);
 	font-size: 0.6666666667rem;
-	font-weight: 500;
 	letter-spacing: 2.7px;
-	line-height: initial;
 	text-transform: uppercase;
 	padding-top: 15px;
 	padding-bottom: 0;
 }
 
 .table a:hover {
-	color: rgb(5, 12, 64) !important;
+	color: var(--text-primary) !important;
 }
 
 .technical-integration {
@@ -342,3 +374,47 @@ table.table.box.versions {
 #mtabs-content div.is-active {
   display: inline-block;
 }
+
+/* Theme Toggle Button */
+.theme-toggle {
+	background: transparent;
+	border: none;
+	cursor: pointer;
+	padding: 8px;
+	margin-left: 10px;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: background-color 0.3s ease;
+}
+
+.theme-toggle:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+.theme-toggle svg {
+	width: 20px;
+	height: 20px;
+	fill: #ffffff;
+	transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover svg {
+	transform: rotate(15deg);
+}
+
+/* Section styling for dark mode */
+.section {
+	background-color: var(--bg-primary);
+}
+
+.table {
+	background-color: var(--table-bg);
+}
+
+/* Code block styling */
+pre, code {
+	background-color: var(--code-bg) !important;
+}
+

--- a/views/page.njk
+++ b/views/page.njk
@@ -5,6 +5,17 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <!-- Theme initialization (prevent FOUC) -->
+        <script>
+         (function() {
+             var savedTheme = localStorage.getItem('theme');
+             if (savedTheme) {
+                 document.documentElement.setAttribute('data-theme', savedTheme);
+             } else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                 document.documentElement.setAttribute('data-theme', 'dark');
+             }
+         })();
+        </script>
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120382669-1"></script>
         <script>
@@ -193,15 +204,51 @@
           <div class="navbar-end">
             <a class="navbar-item" href="https://github.com/accordproject/cicero-template-library" target="_blank">
               <div class="icon">
-                <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" data-prefix="fab" data-icon="github" class="svg-inline--fa fa-github fa-w-16" viewBox="0 0 496 496"><path fill="#fff" d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/>
-                </svg>
+                <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" data-prefix="fab" data-icon="github" class="svg-inline--fa fa-github fa-w-16" viewBox="0 0 496 496"><path fill="#fff" d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>
               </div>
               GitHub
             </a>
+            <!-- Theme Toggle Button -->
+            <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle dark/light mode">
+              <!-- Sun icon (shown in dark mode) -->
+              <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="display: none;">
+                <path d="M12 7a5 5 0 100 10 5 5 0 000-10zM2 13h2a1 1 0 100-2H2a1 1 0 100 2zm18 0h2a1 1 0 100-2h-2a1 1 0 100 2zM11 2v2a1 1 0 102 0V2a1 1 0 10-2 0zm0 18v2a1 1 0 102 0v-2a1 1 0 10-2 0zM5.99 4.58a1 1 0 10-1.41 1.41l1.06 1.06a1 1 0 101.41-1.41L5.99 4.58zm12.37 12.37a1 1 0 10-1.41 1.41l1.06 1.06a1 1 0 101.41-1.41l-1.06-1.06zm1.06-10.96a1 1 0 10-1.41-1.41l-1.06 1.06a1 1 0 101.41 1.41l1.06-1.06zM7.05 18.36a1 1 0 10-1.41-1.41l-1.06 1.06a1 1 0 101.41 1.41l1.06-1.06z"/>
+              </svg>
+              <!-- Moon icon (shown in light mode) -->
+              <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M12 3a9 9 0 109 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 01-4.4 2.26 5.403 5.403 0 01-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/>
+              </svg>
+            </button>
           </div>
         </div>
       </div>
     </nav>
+    
+    <script>
+     // Theme toggle functionality
+     (function() {
+         var toggle = document.getElementById('theme-toggle');
+         var sunIcon = toggle.querySelector('.sun-icon');
+         var moonIcon = toggle.querySelector('.moon-icon');
+         
+         function updateIcons() {
+             var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+             sunIcon.style.display = isDark ? 'block' : 'none';
+             moonIcon.style.display = isDark ? 'none' : 'block';
+         }
+         
+         // Initial icon state
+         updateIcons();
+         
+         toggle.addEventListener('click', function() {
+             var currentTheme = document.documentElement.getAttribute('data-theme');
+             var newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+             document.documentElement.setAttribute('data-theme', newTheme);
+             localStorage.setItem('theme', newTheme);
+             updateIcons();
+         });
+     })();
+    </script>
 
     {% block body %} {% endblock %}
 


### PR DESCRIPTION
# Closes #465

Adds a dark mode toggle button to the template library website that allows users to switch between light and dark themes.

### Changes
- Added CSS custom properties (variables) for theming in [styles.css](cci:7://file:///home/shubhraj/OpenSource/cicero-template-library/styles.css:0:0-0:0)
- Added dark theme color values using `[data-theme="dark"]` selector
- Added toggle button with sun/moon icons to navbar in [views/page.njk](cci:7://file:///home/shubhraj/OpenSource/cicero-template-library/views/page.njk:0:0-0:0)
- Added JavaScript for theme switching and localStorage persistence
- Toggle respects system preference (`prefers-color-scheme`) on first visit

### Flags
- No breaking changes
- No new dependencies added
- Toggle works on all pages (index and template detail pages)

### Screenshots or Video
<img width="1823" height="964" alt="image" src="https://github.com/user-attachments/assets/7430b72e-559c-4d1a-91d6-06d8959aad29" />
<img width="1845" height="962" alt="image" src="https://github.com/user-attachments/assets/efeac25c-5e65-48e8-abac-186f92ad73c9" />

### Related Issues
- Issue #465

### Author Checklist
- [x] Ensure you provide a [DCO sign-off](https://github.com/probot/dco#how-it-works) for your commits using the `--signoff` option of git commit.
- [x] Vital features and changes captured in unit and/or integration tests 
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Extend the documentation, if necessary
- [x] Merging to `master` from `Shubh-Raj/cicero-template-library:shubhraj/i465/add-dark-mode-toggle`