### PR TITLE
fix: correct spelling and grammar in comments and feature files

### DIFF
--- a/src/lateinvoicewithpayment/logic/logic.ergo
+++ b/src/lateinvoicewithpayment/logic/logic.ergo
@@ -28,7 +28,7 @@ contract LateInvoice over LateInvoiceContract {
     // Calculate the time difference between current date and invoice due date
     let diff = diffDurationAs(now(),request.invoiceDue,contract.maximumDelay.unit);
 
-    // Enforce that the invoice has been recieved on time, otherwise terminate
+    // Enforce that the invoice has been received on time, otherwise terminate
     enforce diff.amount <= contract.maximumDelay.amount
     else
       return LateInvoiceResponse{

--- a/src/one-time-payment-tr/logic/logic.ergo
+++ b/src/one-time-payment-tr/logic/logic.ergo
@@ -41,7 +41,7 @@ contract onetimepayment over OneTimePaymentContract state OneTimePaymentState {
   }
 
   /**
-   * Update the contract state once we've recieved a payment
+   * Update the contract state once we've received a payment
    */
   clause paymentReceived(request : PaymentReceived): Response {
     enforce (state.status = OBLIGATION_EMITTED) 

--- a/src/perishable-goods/test/logic.feature
+++ b/src/perishable-goods/test/logic.feature
@@ -84,7 +84,7 @@ Formula for Breach Penalty Calculation:
 ]
 """
 
- Scenario: The contract recieve a shipment with units below the agreed bounds
+ Scenario: The contract receives a shipment with units below the agreed bounds
     When it receives the request
 """
 {
@@ -114,7 +114,7 @@ Formula for Breach Penalty Calculation:
 """
     Then it should reject the request with the error "[Ergo] Units received out of range for the contract"
 
-	Scenario: The contract recieve a shipment with units above the agreed bounds
+	Scenario: The contract receives a shipment with units above the agreed bounds
     When it receives the request
 """
 {
@@ -144,7 +144,7 @@ Formula for Breach Penalty Calculation:
 """
     Then it should reject the request with the error "[Ergo] Units received out of range for the contract"
 
-	Scenario: The contract recieve a shipment with units above the agreed bounds
+	Scenario: The contract receives a shipment with units above the agreed bounds
     When it receives the request
 """
 {

--- a/src/supplyagreement-perishable-goods/test/logic.feature
+++ b/src/supplyagreement-perishable-goods/test/logic.feature
@@ -194,7 +194,7 @@ Formula for Breach Penalty Calculation:
 ]
 """
 
- Scenario: The contract recieve a shipment with units below the agreed bounds
+ Scenario: The contract receives a shipment with units below the agreed bounds
     When it receives the request
 """
 {
@@ -224,7 +224,7 @@ Formula for Breach Penalty Calculation:
 """
     Then it should reject the request with the error "[Ergo] Units received out of range for the contract."
 
-	Scenario: The contract recieve a shipment with units above the agreed bounds
+	Scenario: The contract receives a shipment with units above the agreed bounds
     When it receives the request
 """
 {
@@ -254,7 +254,7 @@ Formula for Breach Penalty Calculation:
 """
     Then it should reject the request with the error "[Ergo] Units received out of range for the contract."
 
-	Scenario: The contract recieve a shipment with units above the agreed bounds
+	Scenario: The contract receives a shipment with units above the agreed bounds
     When it receives the request
 """
 {


### PR DESCRIPTION
# Fixes spelling and grammar

### Changes
- Fix spelling: `recieve` → `receive` in comments in `lateinvoicewithpayment/logic/logic.ergo` and `one-time-payment-tr/logic/logic.ergo`
- Fix grammar: `The contract receive a shipment` → `The contract receives a shipment` in `perishable-goods/test/logic.feature` and `supplyagreement-perishable-goods/test/logic.feature`

### Flags
- No logic changes
- Comments and test scenario descriptions only

### Screenshots or Video
N/A

### Related Issues
N/A

### Author Checklist
- [x] Ensure you provide a DCO sign-off for your commits using the `--signoff` option of git commit.
- [ ] Vital features and changes captured in unit and/or integration tests
- [x] Commits messages follow AP format
- [ ] Extend the documentation, if necessary
- [x] Merging to `main` from `bilal/fix/typo-recieve-to-receive`