### PR TITLE
ci: drop broken npm@latest install in build-and-publish workflow

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -35,8 +35,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm install -g npm@latest
-
       - name: NPM Install
         run: npm install
 


### PR DESCRIPTION
## Summary

The Build-and-Deploy workflow has been failing on every push to \`main\` since [#504](https://github.com/accordproject/cicero-template-library/pull/504) bumped publish to Node 22. The very first step after \`actions/setup-node@v4\` is \`npm install -g npm@latest\`, which on the GitHub-hosted Node 22.22.2 image crashes with:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
\`\`\`

The failure is inside the freshly-installed global npm's bundled \`@npmcli/arborist\` — upstream, not anything in this repo. See run [25939448651](https://github.com/accordproject/cicero-template-library/actions/runs/25939448651) for the full log.

\`actions/setup-node@v4\` already ships a compatible npm for the selected Node version, and this workflow only uses \`npm install\` and \`npm run build\`. The global upgrade step adds nothing and is currently the sole reason every push to main is red.

## What changed

- Removed line 38 of \`.github/workflows/build-and-publish.yml\` (\`- run: npm install -g npm@latest\`).

## Test plan

- [ ] Reviewer: confirm the workflow runs to completion on this PR (the \`Build and Deploy\` workflow only triggers on push to \`main\`, so the green signal will come once this is merged).
- [ ] No application-code changes — \`Build\` workflow (PR-validation) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)