### PR TITLE
fix(test): remove offline validation monkeypatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "src/*"
       ],
       "dependencies": {
-        "@accordproject/cicero-core": "2.0.0",
+        "@accordproject/cicero-core": "2.1.1",
         "@accordproject/concerto-cli": "4.0.1",
         "@accordproject/concerto-codegen": "4.1.3",
         "@accordproject/concerto-core": "4.1.4",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@accordproject/cicero-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-2.0.0.tgz",
-      "integrity": "sha512-3Hhsxcczwu/3mLfqDnps7lnIJ2P5CUOHN01wk4T71yOmOtdW8ur5MNYOwukBmOdWRs0h7Bh/pSJdcwjOkmnwaA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-2.1.1.tgz",
+      "integrity": "sha512-1OkV41WYM7zJhwSjDUOkJfj36OmZNxwEWFATec8Bt2dKKtdijU4T1T/K0M/NriI1W3C/eeSIDTdT/UITzUnvRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@accordproject/concerto-core": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "all": true
   },
   "dependencies": {
-    "@accordproject/cicero-core": "2.0.0",
+    "@accordproject/cicero-core": "2.1.1",
     "@accordproject/concerto-cli": "4.0.1",
     "@accordproject/concerto-core": "4.1.4",
     "@accordproject/concerto-codegen": "4.1.3",

--- a/test/render.test.mjs
+++ b/test/render.test.mjs
@@ -6,11 +6,6 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 
-const originalValidate = Template.prototype.validate;
-Template.prototype.validate = function validateOffline(options = {}) {
-    return originalValidate.call(this, { ...options, offline: true });
-};
-
 const SRC = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
 let templates = readdirSync(SRC).filter(name => {
     const p = join(SRC, name);


### PR DESCRIPTION
# Closes N/A

Remove the test-only global validation monkeypatch now that `cicero-core` preserves offline validation in its loaders.

### Changes

- Upgrade `@accordproject/cicero-core` from `2.0.0` to `2.1.1` and refresh the lockfile.
- Remove the global `Template.prototype.validate` monkeypatch from `test/render.test.mjs`.
- Keep `Template.fromDirectory(templatePath, { offline: true })` at the loader boundary.

### Flags

- No public API changes.
- `cicero-core@2.1.1` forwards `offline: true` through final template validation, so the test no longer needs global state changes.
- Render validation passed: 113 tests passed and 3 existing expected failures remained (`bill-of-lading`, `fixed-interests`, and `supply-agreement-loc`).

### Screenshots or Video

Not applicable; this is a test and dependency update.

### Related Issues

- [template-engine PR #154](https://github.com/accordproject/template-engine/pull/154)
- [template-engine review thread](https://github.com/accordproject/template-engine/pull/154#discussion_r3720805292)
- [template-archive PR #944](https://github.com/accordproject/template-archive/pull/944)

### Author Checklist

- [x] DCO sign-off is present using `--signoff`.
- [x] Vital changes are covered by the render test suite.
- [x] Commit message follows AP format.
- [x] Documentation extension is not required; there are no public API changes.
- [x] Merging to `main` from `Rishabh060105:remove-offline-validation-monkeypatch`.
- [x] Manual accessibility testing is not applicable to test-only changes.
