### PR TITLE
chore: upgrade active templates to latest Cicero v2 toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "src/*"
       ],
       "dependencies": {
-        "@accordproject/cicero-core": "2.0.0",
-        "@accordproject/concerto-cli": "4.0.1",
-        "@accordproject/concerto-codegen": "4.1.3",
-        "@accordproject/concerto-core": "4.1.4",
-        "@accordproject/concerto-util": "4.1.4",
+        "@accordproject/cicero-core": "2.1.1",
+        "@accordproject/concerto-cli": "4.0.2",
+        "@accordproject/concerto-codegen": "5.1.0",
+        "@accordproject/concerto-core": "4.1.5",
+        "@accordproject/concerto-util": "4.1.5",
         "@accordproject/markdown-cicero": "1.0.1",
         "@accordproject/markdown-html": "1.0.1",
         "@accordproject/template-engine": "4.0.0",
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@accordproject/cicero-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-2.0.0.tgz",
-      "integrity": "sha512-3Hhsxcczwu/3mLfqDnps7lnIJ2P5CUOHN01wk4T71yOmOtdW8ur5MNYOwukBmOdWRs0h7Bh/pSJdcwjOkmnwaA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/cicero-core/-/cicero-core-2.1.1.tgz",
+      "integrity": "sha512-1OkV41WYM7zJhwSjDUOkJfj36OmZNxwEWFATec8Bt2dKKtdijU4T1T/K0M/NriI1W3C/eeSIDTdT/UITzUnvRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@accordproject/concerto-core": "4.1.4",
@@ -82,6 +82,81 @@
         "@accordproject/concerto-core": "^4.1.3"
       }
     },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.4.tgz",
+      "integrity": "sha512-Fc0S/+jQUPxouhN/onRoVjSV+WYm/yjCzKN3JEM0mzV8lHXBtLOR6SQtOfJC8Ott0JIySKI9J4QtBKpicIHdQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "4.1.4",
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.4",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-core/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/@accordproject/concerto-util": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.4.tgz",
+      "integrity": "sha512-FifiXZkUIZisSxG6AJ9ORR/+EULHKxk9qeW69pffLei+WpmSUJDFSp4gHiW8hb11Z46IXO+/9RqdcJfXYI43eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
     "node_modules/@accordproject/cicero-core/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -93,6 +168,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@accordproject/cicero-core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/@accordproject/cicero-core/node_modules/semver": {
       "version": "7.5.3",
@@ -109,6 +190,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/@accordproject/cicero-core/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@accordproject/cicero-core/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -116,110 +210,18 @@
       "license": "ISC"
     },
     "node_modules/@accordproject/concerto-analysis": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-4.1.2.tgz",
-      "integrity": "sha512-w3d9ths1jtbHnD4HttKtlV/KcIkcGq3VhwA7VKYEx1rkufcLfpSoVD1jLhVQ+ct784nRAC/pjIUq9+V9nFl+vA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-analysis/-/concerto-analysis-4.1.5.tgz",
+      "integrity": "sha512-pPTGva/uCKYVvk0yFtSa+JftjU3zr1sITBPHIxZLmSyxGZQTSyh2ewLcWLh6U1HMXIjL/X6JlrKHcyFsT6AtuA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "4.1.2",
+        "@accordproject/concerto-core": "4.1.5",
         "semver": "7.5.4"
       },
       "engines": {
         "node": ">=18",
         "npm": ">=10"
       }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-core": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.2.tgz",
-      "integrity": "sha512-2k5J4Rwb50DZQwdMS1hQMNwHMqtETTjkqSjVXYopemzNjYdlGAF+6FrRl2cC7zfxIffiQbd0FJPbE0bDJ0mf+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "4.1.2",
-        "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "^2.8.3"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-core/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-core/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-cto": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.2.tgz",
-      "integrity": "sha512-oidSD2YC26YRiuEUctgYhIN2HMnNRA4TH/rTvMdmLUJasfD947TYCh4XwtJ4YNcjpRy80TRmCwcup7O/CIQ0vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
-        "acorn": "^8.15.0",
-        "path-browserify": "^1.0.1",
-        "schema-utils": "^4.3.3"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/@accordproject/concerto-util": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.2.tgz",
-      "integrity": "sha512-pHtZuWDrLXuNLrpyGaoRKcSW5fBZyrnz9IQ27aNnQt+JLSTovQzkw/JHuPUSi9EWZBC1/Ak/yUCiDpLjHfV1Dg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-analysis/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -232,12 +234,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@accordproject/concerto-analysis/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-analysis/node_modules/semver": {
       "version": "7.5.4",
@@ -254,19 +250,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@accordproject/concerto-analysis/node_modules/uuid": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@accordproject/concerto-analysis/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -274,18 +257,18 @@
       "license": "ISC"
     },
     "node_modules/@accordproject/concerto-cli": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cli/-/concerto-cli-4.0.1.tgz",
-      "integrity": "sha512-c9LmMCrAspcuqcULcOZwZ1fcFJJJVY+r8/LEKgR7EwtupIMJUkXihd1S8aea/CztLfbdIS8MHOGZqAq+IyM5lw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cli/-/concerto-cli-4.0.2.tgz",
+      "integrity": "sha512-bzFy5kX0a/uaOAAWskcZ0OjevnGjy6Xx+BwcxPrUeRa3Kan6T53tnSKcXYhhwCxCzDtyW9GnECWxuYg5bikRgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-analysis": "4.1.2",
-        "@accordproject/concerto-codegen": "4.1.1",
-        "@accordproject/concerto-core": "4.1.2",
-        "@accordproject/concerto-cto": "4.1.2",
-        "@accordproject/concerto-linter": "4.1.2",
-        "@accordproject/concerto-metamodel": "3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
+        "@accordproject/concerto-analysis": "4.1.5",
+        "@accordproject/concerto-codegen": "5.1.0",
+        "@accordproject/concerto-core": "4.1.5",
+        "@accordproject/concerto-cto": "4.1.5",
+        "@accordproject/concerto-linter": "4.1.5",
+        "@accordproject/concerto-metamodel": "3.13.1",
+        "@accordproject/concerto-util": "4.1.5",
         "ansi-colors": "4.1.3",
         "glob": "7.2.3",
         "randexp": "0.5.3",
@@ -300,92 +283,14 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/concerto-cli/node_modules/@accordproject/concerto-codegen": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-4.1.1.tgz",
-      "integrity": "sha512-1fKBd0AnYCPwgDcKun7hUA6rUPL2i7HsCeMRlyqyB9C5aI91khWTxx5DErLfojF/1pDmdPf2R1lPIJlKg88raQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@openapi-contrib/openapi-schema-to-json-schema": "4.0.0",
-        "ajv": "8.18.0",
-        "ajv-formats": "3.0.1",
-        "camelcase": "6.3.0",
-        "debug": "4.3.4",
-        "get-value": "3.0.1",
-        "json-schema-migrate": "2.0.0",
-        "pluralize": "8.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@accordproject/concerto-core": "^4.1.2",
-        "@accordproject/concerto-util": "^4.1.2",
-        "@accordproject/concerto-vocabulary": "^4.1.2"
-      }
-    },
-    "node_modules/@accordproject/concerto-cli/node_modules/@accordproject/concerto-core": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.2.tgz",
-      "integrity": "sha512-2k5J4Rwb50DZQwdMS1hQMNwHMqtETTjkqSjVXYopemzNjYdlGAF+6FrRl2cC7zfxIffiQbd0FJPbE0bDJ0mf+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "4.1.2",
-        "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "^2.8.3"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-cli/node_modules/@accordproject/concerto-core/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/concerto-cli/node_modules/@accordproject/concerto-core/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@accordproject/concerto-cli/node_modules/@accordproject/concerto-cto": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.2.tgz",
-      "integrity": "sha512-oidSD2YC26YRiuEUctgYhIN2HMnNRA4TH/rTvMdmLUJasfD947TYCh4XwtJ4YNcjpRy80TRmCwcup7O/CIQ0vA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.5.tgz",
+      "integrity": "sha512-rRNLTHv0s6dH2YGEruLeT1gQi3ySkkkGn8Al/xry9BEDp0AavgIWBPTIfgRSklRH9Rrn01/V2gmO6g+10ByL9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
+        "@accordproject/concerto-util": "4.1.5",
         "acorn": "^8.15.0",
         "path-browserify": "^1.0.1",
         "schema-utils": "^4.3.3"
@@ -394,28 +299,6 @@
         "node": ">=18",
         "npm": ">=9"
       }
-    },
-    "node_modules/@accordproject/concerto-cli/node_modules/@accordproject/concerto-util": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.2.tgz",
-      "integrity": "sha512-pHtZuWDrLXuNLrpyGaoRKcSW5fBZyrnz9IQ27aNnQt+JLSTovQzkw/JHuPUSi9EWZBC1/Ak/yUCiDpLjHfV1Dg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-cli/node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-cli/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -428,12 +311,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@accordproject/concerto-cli/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/@accordproject/concerto-cli/node_modules/semver": {
       "version": "7.5.2",
@@ -450,19 +327,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@accordproject/concerto-cli/node_modules/uuid": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/@accordproject/concerto-cli/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -470,9 +334,9 @@
       "license": "ISC"
     },
     "node_modules/@accordproject/concerto-codegen": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-4.1.3.tgz",
-      "integrity": "sha512-a1OvKHIFNnJNJ0+AxgWIG4RAe7PQ+P0CJZufu4f+6YIeaEDHln5Y7uBcnnXFVMc76XbnKXteLdmVBuIPjG+DDQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-5.1.0.tgz",
+      "integrity": "sha512-9Urza9BCMG2iddKPMkDiqwbbqbfkhSYOp13c+alIB7HvqlRhjY4IGudKGMCL+V6Cs/vnwOh8H1ZsvSzbtYGZbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@openapi-contrib/openapi-schema-to-json-schema": "4.0.0",
@@ -495,14 +359,14 @@
       }
     },
     "node_modules/@accordproject/concerto-core": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.4.tgz",
-      "integrity": "sha512-Fc0S/+jQUPxouhN/onRoVjSV+WYm/yjCzKN3JEM0mzV8lHXBtLOR6SQtOfJC8Ott0JIySKI9J4QtBKpicIHdQw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.5.tgz",
+      "integrity": "sha512-flbKeQXK0ByjPbXZ7cG0Ef7u0TGHzW8ZoUMqEy1TJrDhJLwwYCQz6fqT6bv2L/AiiGFOT4jNvIOHTobknPT/0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-cto": "4.1.4",
+        "@accordproject/concerto-cto": "4.1.5",
         "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.4",
+        "@accordproject/concerto-util": "4.1.5",
         "dayjs": "1.11.13",
         "debug": "4.3.7",
         "lorem-ipsum": "2.0.8",
@@ -512,6 +376,23 @@
         "urijs": "1.19.11",
         "uuid": "11.0.3",
         "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-core/node_modules/@accordproject/concerto-cto": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.5.tgz",
+      "integrity": "sha512-rRNLTHv0s6dH2YGEruLeT1gQi3ySkkkGn8Al/xry9BEDp0AavgIWBPTIfgRSklRH9Rrn01/V2gmO6g+10ByL9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.5",
+        "acorn": "^8.15.0",
+        "path-browserify": "^1.0.1",
+        "schema-utils": "^4.3.3"
       },
       "engines": {
         "node": ">=18",
@@ -589,15 +470,31 @@
         "npm": ">=9"
       }
     },
-    "node_modules/@accordproject/concerto-linter": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-linter/-/concerto-linter-4.1.2.tgz",
-      "integrity": "sha512-Z5cZi1x3Eoiz+h9OqNhWajLyGR7RteoEKooor0P33HwmkjTzS4dKc/ld28stAefq8nOO3w8wujEmX92+mNK/0g==",
+    "node_modules/@accordproject/concerto-cto/node_modules/@accordproject/concerto-util": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.4.tgz",
+      "integrity": "sha512-FifiXZkUIZisSxG6AJ9ORR/+EULHKxk9qeW69pffLei+WpmSUJDFSp4gHiW8hb11Z46IXO+/9RqdcJfXYI43eA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "4.1.2",
-        "@accordproject/concerto-cto": "4.1.2",
-        "@accordproject/concerto-linter-default-ruleset": "4.1.2",
+        "@supercharge/promise-pool": "1.7.0",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/concerto-linter": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-linter/-/concerto-linter-4.1.5.tgz",
+      "integrity": "sha512-LdYThUiQNMWVNh2Zysd+7sqJJrhtkEYM2oXZU34Mhw/1JfEUccN39vfPqTksPvZkLp9o0ZFl6thRnvHjXYt7vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-core": "4.1.5",
+        "@accordproject/concerto-cto": "4.1.5",
+        "@accordproject/concerto-linter-default-ruleset": "4.1.5",
         "@accordproject/concerto-metamodel": "^3.13.0",
         "@stoplight/spectral-cli": "6.15.0",
         "@stoplight/spectral-core": "1.20.0",
@@ -611,12 +508,12 @@
       }
     },
     "node_modules/@accordproject/concerto-linter-default-ruleset": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-linter-default-ruleset/-/concerto-linter-default-ruleset-4.1.2.tgz",
-      "integrity": "sha512-k1nqQjOaOQu+LThffcnB4/SuVxzCZWPJYbJ+c2AqtbeMEYtYv6G+sD4M95xoQ1rYiLjACVtwEyScEKPdEWz4vA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-linter-default-ruleset/-/concerto-linter-default-ruleset-4.1.5.tgz",
+      "integrity": "sha512-AQZipC8FYZc+iCVyehO16XEAmGEBa5vNYHtGfwFiGwOVIaqwoACD6urKuCBMl7BV1K3ZFa7PCVB/c+SDK09rgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@accordproject/concerto-core": "4.1.2",
+        "@accordproject/concerto-core": "4.1.5",
         "@stoplight/spectral-core": "1.20.0",
         "@stoplight/spectral-functions": "1.10.1",
         "@stoplight/spectral-parsers": "1.0.5"
@@ -626,166 +523,14 @@
         "npm": ">=10"
       }
     },
-    "node_modules/@accordproject/concerto-linter-default-ruleset/node_modules/@accordproject/concerto-core": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.2.tgz",
-      "integrity": "sha512-2k5J4Rwb50DZQwdMS1hQMNwHMqtETTjkqSjVXYopemzNjYdlGAF+6FrRl2cC7zfxIffiQbd0FJPbE0bDJ0mf+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "4.1.2",
-        "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "^2.8.3"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter-default-ruleset/node_modules/@accordproject/concerto-core/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@accordproject/concerto-linter-default-ruleset/node_modules/@accordproject/concerto-cto": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.2.tgz",
-      "integrity": "sha512-oidSD2YC26YRiuEUctgYhIN2HMnNRA4TH/rTvMdmLUJasfD947TYCh4XwtJ4YNcjpRy80TRmCwcup7O/CIQ0vA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
-        "acorn": "^8.15.0",
-        "path-browserify": "^1.0.1",
-        "schema-utils": "^4.3.3"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter-default-ruleset/node_modules/@accordproject/concerto-util": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.2.tgz",
-      "integrity": "sha512-pHtZuWDrLXuNLrpyGaoRKcSW5fBZyrnz9IQ27aNnQt+JLSTovQzkw/JHuPUSi9EWZBC1/Ak/yUCiDpLjHfV1Dg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter-default-ruleset/node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/concerto-linter-default-ruleset/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/concerto-linter-default-ruleset/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter-default-ruleset/node_modules/uuid": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter/node_modules/@accordproject/concerto-core": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.2.tgz",
-      "integrity": "sha512-2k5J4Rwb50DZQwdMS1hQMNwHMqtETTjkqSjVXYopemzNjYdlGAF+6FrRl2cC7zfxIffiQbd0FJPbE0bDJ0mf+A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@accordproject/concerto-cto": "4.1.2",
-        "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
-        "dayjs": "1.11.13",
-        "debug": "4.3.7",
-        "lorem-ipsum": "2.0.8",
-        "randexp": "0.5.3",
-        "rfdc": "1.4.1",
-        "semver": "7.6.3",
-        "urijs": "1.19.11",
-        "uuid": "11.0.3",
-        "yaml": "^2.8.3"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter/node_modules/@accordproject/concerto-core/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@accordproject/concerto-linter/node_modules/@accordproject/concerto-cto": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.2.tgz",
-      "integrity": "sha512-oidSD2YC26YRiuEUctgYhIN2HMnNRA4TH/rTvMdmLUJasfD947TYCh4XwtJ4YNcjpRy80TRmCwcup7O/CIQ0vA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-cto/-/concerto-cto-4.1.5.tgz",
+      "integrity": "sha512-rRNLTHv0s6dH2YGEruLeT1gQi3ySkkkGn8Al/xry9BEDp0AavgIWBPTIfgRSklRH9Rrn01/V2gmO6g+10ByL9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@accordproject/concerto-metamodel": "^3.13.0",
-        "@accordproject/concerto-util": "4.1.2",
+        "@accordproject/concerto-util": "4.1.5",
         "acorn": "^8.15.0",
         "path-browserify": "^1.0.1",
         "schema-utils": "^4.3.3"
@@ -793,65 +538,12 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter/node_modules/@accordproject/concerto-util": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.2.tgz",
-      "integrity": "sha512-pHtZuWDrLXuNLrpyGaoRKcSW5fBZyrnz9IQ27aNnQt+JLSTovQzkw/JHuPUSi9EWZBC1/Ak/yUCiDpLjHfV1Dg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@supercharge/promise-pool": "1.7.0",
-        "colors": "1.4.0",
-        "debug": "4.3.4",
-        "slash": "3.0.0"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=9"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter/node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/concerto-linter/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@accordproject/concerto-linter/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@accordproject/concerto-linter/node_modules/uuid": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
-      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@accordproject/concerto-metamodel": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.0.tgz",
-      "integrity": "sha512-BkWJLYvWkDAG1lPgEr0T/4IqhjqEqzMVxAfFdJzDH3lxfEJsZ+bVJZzdcsHZUubuO0SsoahuHSs4j2Cv7DQ+Lw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-metamodel/-/concerto-metamodel-3.13.1.tgz",
+      "integrity": "sha512-af8mpDuHGSfBH+VlVRwBqhiBVrLI0srRslT44Q4hkZJJHHnxU5K5U2wznGamazP1FMXLnOwXiFG4ZMudAll7Vw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14",
@@ -859,9 +551,9 @@
       }
     },
     "node_modules/@accordproject/concerto-util": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.4.tgz",
-      "integrity": "sha512-FifiXZkUIZisSxG6AJ9ORR/+EULHKxk9qeW69pffLei+WpmSUJDFSp4gHiW8hb11Z46IXO+/9RqdcJfXYI43eA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.5.tgz",
+      "integrity": "sha512-9wBw9XjiNql9CMajfC2GJORUKHhh6E+ZJod2zjw1ItrvFQQaKt80T3SgzBlZ6XG/wEfgFqyypyU0XwLYGlUy+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "1.7.0",
@@ -1348,6 +1040,100 @@
         "@accordproject/concerto-core": "^4.1.3"
       }
     },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-codegen": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-codegen/-/concerto-codegen-4.1.3.tgz",
+      "integrity": "sha512-a1OvKHIFNnJNJ0+AxgWIG4RAe7PQ+P0CJZufu4f+6YIeaEDHln5Y7uBcnnXFVMc76XbnKXteLdmVBuIPjG+DDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openapi-contrib/openapi-schema-to-json-schema": "4.0.0",
+        "ajv": "8.18.0",
+        "ajv-formats": "3.0.1",
+        "camelcase": "6.3.0",
+        "debug": "4.3.4",
+        "get-value": "3.0.1",
+        "json-schema-migrate": "2.0.0",
+        "pluralize": "8.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@accordproject/concerto-core": "^4.1.3",
+        "@accordproject/concerto-util": "^4.1.3",
+        "@accordproject/concerto-vocabulary": "^4.1.3"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-core": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-core/-/concerto-core-4.1.4.tgz",
+      "integrity": "sha512-Fc0S/+jQUPxouhN/onRoVjSV+WYm/yjCzKN3JEM0mzV8lHXBtLOR6SQtOfJC8Ott0JIySKI9J4QtBKpicIHdQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@accordproject/concerto-cto": "4.1.4",
+        "@accordproject/concerto-metamodel": "^3.13.0",
+        "@accordproject/concerto-util": "4.1.4",
+        "dayjs": "1.11.13",
+        "debug": "4.3.7",
+        "lorem-ipsum": "2.0.8",
+        "randexp": "0.5.3",
+        "rfdc": "1.4.1",
+        "semver": "7.6.3",
+        "urijs": "1.19.11",
+        "uuid": "11.0.3",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-core/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-core/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/@accordproject/concerto-util": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@accordproject/concerto-util/-/concerto-util-4.1.4.tgz",
+      "integrity": "sha512-FifiXZkUIZisSxG6AJ9ORR/+EULHKxk9qeW69pffLei+WpmSUJDFSp4gHiW8hb11Z46IXO+/9RqdcJfXYI43eA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@supercharge/promise-pool": "1.7.0",
+        "colors": "1.4.0",
+        "debug": "4.3.4",
+        "slash": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
     "node_modules/@accordproject/template-engine/node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -1366,6 +1152,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/@accordproject/template-engine/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/@accordproject/template-engine/node_modules/semver": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
@@ -1379,6 +1171,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@accordproject/template-engine/node_modules/uuid": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@accordproject/template-engine/node_modules/yallist": {
@@ -2650,6 +2455,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -2812,9 +2624,9 @@
       "license": "MIT"
     },
     "node_modules/@stoplight/spectral-cli/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -2907,18 +2719,94 @@
       "license": "MIT"
     },
     "node_modules/@stoplight/spectral-formats": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.8.2.tgz",
-      "integrity": "sha512-c06HB+rOKfe7tuxg0IdKDEA5XnjL2vrn/m/OVIIxtINtBzphZrOgtRn7epQ5bQF5SWp84Ue7UJWaGgDwVngMFw==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-formats/-/spectral-formats-1.8.5.tgz",
+      "integrity": "sha512-xaC0rCH0p7/bzNJsz+JgLSj+Cp6uwYGWpePQxdLkF2G6a8Zyp3OyS7umkGYNiimEwKrOjvCNNTFJpeuiENZSBA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@scarf/scarf": "^1.4.0",
         "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.19.2",
+        "@stoplight/spectral-core": "^1.23.0",
         "@types/json-schema": "^7.0.7",
         "tslib": "^2.8.1"
       },
       "engines": {
         "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-formats/node_modules/@stoplight/spectral-core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.23.1.tgz",
+      "integrity": "sha512-VLC8OhpO/pMJKb6IHhurxJjXO1qB56Ng1unIb8b+hNxdw0+SEcASvmR+RpjfHYX/jv/DfSaA1x8QhFBJBmqBOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-parsers": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "~13.6.0",
+        "@types/es-aggregate-error": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "ajv": "^8.18.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.1",
+        "es-aggregate-error": "^1.0.7",
+        "expr-eval-fork": "^3.0.1",
+        "jsonpath-plus": "^10.3.0",
+        "lodash": "^4.18.1",
+        "lodash.topath": "^4.5.2",
+        "minimatch": "^3.1.4",
+        "nimma": "0.2.3",
+        "pony-cause": "^1.1.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-formats/node_modules/@stoplight/types": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.6.0.tgz",
+      "integrity": "sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
+      }
+    },
+    "node_modules/@stoplight/spectral-formats/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@stoplight/spectral-formats/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@stoplight/spectral-formatters": {
@@ -3062,9 +2950,9 @@
       }
     },
     "node_modules/@stoplight/spectral-ruleset-migrator": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.1.tgz",
-      "integrity": "sha512-IUEbDmmTro0oF6VoAtrUySRV/b6bvYmV7wV6lB99f0Ym5lF9M2DXcgPLo7VMbKTPjCOQcaBzWRnIMXAyLjIRMA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-ruleset-migrator/-/spectral-ruleset-migrator-1.12.2.tgz",
+      "integrity": "sha512-9hTcyXnBGppM1kMA8vVvY6aWzF3vXbU7+mZvvd9wdPE8QdHj9NO//1s+A/TfiWOKdH9GOERC5NITCnVvbEYEWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "~3.21.0",
@@ -3108,15 +2996,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/@stoplight/spectral-rulesets": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.3.tgz",
-      "integrity": "sha512-CDkXEsrA1OOQPmF0VE92zira+eSI411s7hyIdfVeS/91BrNz3Y5HJgnwWFbh2abKVJ2rNciOzBPyGar+xfiFKA==",
+      "version": "1.22.7",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-rulesets/-/spectral-rulesets-1.22.7.tgz",
+      "integrity": "sha512-cT1B6Ly21923lvr235lu7iIgmcnoCTJaN3ANOyTqr4D5GA/4p2k0+yhjhdfj/1ks/Os3kUzSFnFkzpWH7WszFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/specs": "^6.8.0",
+        "@asyncapi/specs": "6.11.1",
+        "@scarf/scarf": "^1.4.0",
         "@stoplight/better-ajv-errors": "1.0.3",
         "@stoplight/json": "^3.17.0",
-        "@stoplight/spectral-core": "^1.19.4",
+        "@stoplight/spectral-core": "^1.23.0",
         "@stoplight/spectral-formats": "^1.8.1",
         "@stoplight/spectral-functions": "^1.9.1",
         "@stoplight/spectral-runtime": "^1.1.2",
@@ -3131,6 +3020,52 @@
       },
       "engines": {
         "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-rulesets/node_modules/@stoplight/spectral-core": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-core/-/spectral-core-1.23.1.tgz",
+      "integrity": "sha512-VLC8OhpO/pMJKb6IHhurxJjXO1qB56Ng1unIb8b+hNxdw0+SEcASvmR+RpjfHYX/jv/DfSaA1x8QhFBJBmqBOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "^1.4.0",
+        "@stoplight/better-ajv-errors": "1.0.3",
+        "@stoplight/json": "~3.21.0",
+        "@stoplight/path": "1.3.2",
+        "@stoplight/spectral-parsers": "^1.0.0",
+        "@stoplight/spectral-ref-resolver": "^1.0.4",
+        "@stoplight/spectral-runtime": "^1.1.2",
+        "@stoplight/types": "~13.6.0",
+        "@types/es-aggregate-error": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "ajv": "^8.18.0",
+        "ajv-errors": "~3.0.0",
+        "ajv-formats": "~2.1.1",
+        "es-aggregate-error": "^1.0.7",
+        "expr-eval-fork": "^3.0.1",
+        "jsonpath-plus": "^10.3.0",
+        "lodash": "^4.18.1",
+        "lodash.topath": "^4.5.2",
+        "minimatch": "^3.1.4",
+        "nimma": "0.2.3",
+        "pony-cause": "^1.1.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": "^16.20 || ^18.18 || >= 20.17"
+      }
+    },
+    "node_modules/@stoplight/spectral-rulesets/node_modules/@stoplight/types": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-13.6.0.tgz",
+      "integrity": "sha512-dzyuzvUjv3m1wmhPfq82lCVYGcXG0xUYgqnWfCq3PCVR4BKFhjdkHrnJ+jIDoMKvXb05AZP/ObQF6+NpDo29IQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.4",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": "^12.20 || >=14.13"
       }
     },
     "node_modules/@stoplight/spectral-rulesets/node_modules/ajv-formats": {
@@ -3150,16 +3085,27 @@
         }
       }
     },
+    "node_modules/@stoplight/spectral-rulesets/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@stoplight/spectral-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.5.tgz",
-      "integrity": "sha512-6/HSCQBKnI4M5qonCKos2W7oggXv+U/ml+m/cAd4eJAYfIVEmaLUo03qSWIIl4cBc5ujJPmn2WnCiRrz1++P7Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@stoplight/spectral-runtime/-/spectral-runtime-1.1.6.tgz",
+      "integrity": "sha512-Y8rEDyMN4bSMJCrDs2shdcVHYyCnH3FvXRP4dBhha4Z8iJv+JPp7KqOV/hwVB/hWFC209upiwj2oDmLfR0qCDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/json": "^3.20.1",
         "@stoplight/path": "^1.3.2",
         "@stoplight/types": "^13.6.0",
-        "abort-controller": "^3.0.0",
         "lodash": "^4.18.1",
         "node-fetch": "^2.7.0",
         "tslib": "^2.8.1"
@@ -3566,18 +3512,6 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "deprecated": "Use your platform's native atob() and btoa() methods instead",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/acceptance-of-delivery": {
       "resolved": "src/acceptance-of-delivery",
@@ -4995,15 +4929,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5012,6 +4937,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expr-eval-fork": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/expr-eval-fork/-/expr-eval-fork-3.0.3.tgz",
+      "integrity": "sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/extend": {
@@ -25260,11 +25194,11 @@
       }
     },
     "src/acceptance-of-delivery": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/bill-of-lading": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/car-rental-tr": {
@@ -25272,32 +25206,32 @@
       "license": "Apache-2.0"
     },
     "src/certificate-of-incorporation": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/company-information": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/contact-information": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/copyright-license": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/demandforecast": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/docusign-connect": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/docusign-po-failure": {
       "name": "purchase-order-failure",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/eat-apples": {
@@ -25305,15 +25239,15 @@
       "license": "Apache-2.0"
     },
     "src/empty": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/empty-contract": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/fixed-interests": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/fixed-interests-static": {
@@ -25321,11 +25255,11 @@
       "license": "Apache-2.0"
     },
     "src/fragile-goods": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/full-payment-upon-demand": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/full-payment-upon-signature": {
@@ -25337,27 +25271,27 @@
       "license": "Apache-2.0"
     },
     "src/helloworld": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/helloworldstate": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/installment-sale": {
-      "version": "6.0.0",
+      "version": "6.0.1",
       "license": "Apache-2.0"
     },
     "src/interest-rate-swap": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/ip-payment": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/latedeliveryandpenalty": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/latedeliveryandpenalty-currency-conversion": {
@@ -25377,11 +25311,11 @@
       "license": "Apache-2.0"
     },
     "src/lateinvoicewithpayment": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/minilatedeliveryandpenalty": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/minilatedeliveryandpenalty-capped": {
@@ -25401,27 +25335,27 @@
       "license": "Apache-2.0"
     },
     "src/payment-upon-delivery": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/payment-upon-iot": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/payment-upon-signature": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/perishable-goods": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/project-information": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/promissory-note": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/promissory-note-md": {
@@ -25429,7 +25363,7 @@
       "license": "Apache-2.0"
     },
     "src/rental-deposit": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/rental-deposit-with": {
@@ -25437,15 +25371,15 @@
       "license": "Apache-2.0"
     },
     "src/roommate": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/saft": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/safte": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/sales-contract-ru": {
@@ -25453,7 +25387,7 @@
       "license": "Apache-2.0"
     },
     "src/servicelevelagreement": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/signature-block-title-name-date": {
@@ -25465,19 +25399,19 @@
       "license": "Apache-2.0"
     },
     "src/supply-agreement-loc": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/supplyagreement": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/supplyagreement-perishable-goods": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/volumediscount": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0"
     },
     "src/volumediscountolist": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "all": true
   },
   "dependencies": {
-    "@accordproject/cicero-core": "2.0.0",
-    "@accordproject/concerto-cli": "4.0.1",
-    "@accordproject/concerto-core": "4.1.4",
-    "@accordproject/concerto-codegen": "4.1.3",
-    "@accordproject/concerto-util": "4.1.4",
+    "@accordproject/cicero-core": "2.1.1",
+    "@accordproject/concerto-cli": "4.0.2",
+    "@accordproject/concerto-core": "4.1.5",
+    "@accordproject/concerto-codegen": "5.1.0",
+    "@accordproject/concerto-util": "4.1.5",
     "@accordproject/markdown-cicero": "1.0.1",
     "@accordproject/markdown-html": "1.0.1",
     "@accordproject/template-engine": "4.0.0",

--- a/scripts/upgrade-cicero-v2.mjs
+++ b/scripts/upgrade-cicero-v2.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Upgrades active templates to the latest Cicero v2 toolchain.
+//
+// What it does:
+//   1. Bumps the @accordproject/* dependencies in the root package.json to
+//      the pinned TARGET_VERSIONS below.
+//   2. For every active template (package.json `archived` !== true):
+//      - normalizes `accordproject.cicero` to `^2.0.0`
+//      - removes any stray top-level `engines` block (legacy pre-v2 templates
+//        declared engines.cicero directly; none currently do, but this keeps
+//        the script correct if one reappears via a bad merge/copy-paste)
+//      - bumps the template's own `version` (default: patch)
+//   Archived templates are skipped by default since they're retired and no
+//   longer expected to compile (see test/render.test.mjs).
+//
+// What it does NOT do:
+//   - Run `npm install`, regenerate lockfiles, or run `npm run compile`.
+//   - Touch model/*.cto, logic/*.ts, or sample.json — this is a pure
+//     tooling/dependency bump, not a model migration.
+//   - Verify the upgrade actually works. @accordproject/concerto-codegen is
+//     jumping a major version (4.x -> 5.x) as a transitive pull-in via
+//     concerto-cli, which regenerates logic/generated/. After applying,
+//     run `npm install && npm run compile --workspaces --if-present &&
+//     npm test` and diff logic/generated/ before committing.
+//
+// Flags:
+//   --dry                 print planned changes without writing (default: write)
+//   --template <list>     comma-separated template names to target (default: all active)
+//   --include-archived    also update archived templates
+//   --bump <level>        patch|minor|major bump for template `version` (default: patch)
+//
+// Target versions below were the latest @accordproject/* v2-line releases on
+// npm as of 2026-08-09 (checked via `npm view <pkg> version`). Re-verify
+// before relying on this list if it's been a while — re-run:
+//   for p in $(node -e "console.log(Object.keys(require('./scripts/upgrade-cicero-v2.mjs').TARGET_VERSIONS||{}).join(' '))"); do npm view "$p" version; done
+// (or just `npm view <pkg> version` per package below).
+
+import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, '..');
+const SRC = join(ROOT, 'src');
+
+// Pinned deliberately (not auto-fetched) so the diff this script produces is
+// exactly what gets reviewed — bumping this list is itself a reviewable change.
+const TARGET_VERSIONS = {
+    '@accordproject/cicero-core': '2.1.1',
+    '@accordproject/concerto-cli': '4.0.2',
+    '@accordproject/concerto-core': '4.1.5',
+    // major bump 4.1.3 -> 5.1.0: concerto-cli@4.0.2 already pulls
+    // concerto-codegen@5.1.0 transitively, so pin here to match rather than
+    // let npm resolve two majors side by side. Verify `npm run compile`
+    // output is unchanged (or intentionally different) before merging.
+    '@accordproject/concerto-codegen': '5.1.0',
+    '@accordproject/concerto-util': '4.1.5',
+    // already latest on the v2 line; listed for completeness / future reruns
+    '@accordproject/markdown-cicero': '1.0.1',
+    '@accordproject/markdown-html': '1.0.1',
+    '@accordproject/template-engine': '4.0.0',
+};
+
+const TARGET_CICERO_RANGE = '^2.0.0';
+
+const args = process.argv.slice(2);
+const opts = { dry: false, template: null, includeArchived: false, bump: 'patch' };
+for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--dry') opts.dry = true;
+    else if (args[i] === '--template') opts.template = args[++i].split(',').map((s) => s.trim());
+    else if (args[i] === '--include-archived') opts.includeArchived = true;
+    else if (args[i] === '--bump') opts.bump = args[++i];
+    else {
+        console.error(`unknown flag: ${args[i]}`);
+        process.exit(1);
+    }
+}
+if (!['patch', 'minor', 'major'].includes(opts.bump)) {
+    console.error(`--bump must be patch|minor|major, got: ${opts.bump}`);
+    process.exit(1);
+}
+
+function bumpVersion(version, level) {
+    const m = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+    if (!m) throw new Error(`unexpected version: ${version}`);
+    const major = Number(m[1]);
+    const minor = Number(m[2]);
+    const patch = Number(m[3]);
+    if (level === 'major') return `${major + 1}.0.0`;
+    if (level === 'minor') return `${major}.${minor + 1}.0`;
+    return `${major}.${minor}.${patch + 1}`;
+}
+
+function updateRootPackage() {
+    const pkgPath = join(ROOT, 'package.json');
+    const raw = readFileSync(pkgPath, 'utf8');
+    const pkg = JSON.parse(raw);
+    const changes = [];
+
+    for (const [dep, target] of Object.entries(TARGET_VERSIONS)) {
+        const current = pkg.dependencies?.[dep];
+        if (!current) {
+            console.warn(`root package.json: ${dep} not found in dependencies, skipping`);
+            continue;
+        }
+        if (current !== target) {
+            changes.push({ dep, from: current, to: target });
+            pkg.dependencies[dep] = target;
+        }
+    }
+
+    console.log('\n== root package.json ==');
+    if (changes.length === 0) {
+        console.log('  no dependency changes needed (already at target versions)');
+    } else {
+        for (const c of changes) console.log(`  ${c.dep}: ${c.from} -> ${c.to}`);
+    }
+    console.log(`  engines.node: ${pkg.engines?.node ?? '(none)'} (left unchanged — no upstream engines requirement forces a bump; confirm manually if desired)`);
+
+    if (!opts.dry && changes.length > 0) {
+        writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+    }
+    return changes;
+}
+
+function discoverTemplates() {
+    let names = readdirSync(SRC).filter((n) => {
+        const p = join(SRC, n);
+        return statSync(p).isDirectory() && existsSync(join(p, 'package.json'));
+    });
+    if (opts.template) {
+        const wanted = new Set(opts.template);
+        names = names.filter((n) => wanted.has(n));
+    }
+    return names;
+}
+
+function updateTemplate(name) {
+    const pkgPath = join(SRC, name, 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+
+    if (pkg.archived === true && !opts.includeArchived) {
+        return { name, skipped: 'archived' };
+    }
+
+    const changes = [];
+
+    if (!pkg.accordproject) pkg.accordproject = {};
+    if (pkg.accordproject.cicero !== TARGET_CICERO_RANGE) {
+        changes.push(`accordproject.cicero: ${pkg.accordproject.cicero ?? '(none)'} -> ${TARGET_CICERO_RANGE}`);
+        pkg.accordproject.cicero = TARGET_CICERO_RANGE;
+    }
+
+    if (pkg.engines) {
+        changes.push(`removed stray top-level engines block: ${JSON.stringify(pkg.engines)}`);
+        delete pkg.engines;
+    }
+
+    const oldVersion = pkg.version;
+    const newVersion = bumpVersion(oldVersion, opts.bump);
+    changes.push(`version: ${oldVersion} -> ${newVersion}`);
+    pkg.version = newVersion;
+
+    if (!opts.dry && changes.length > 0) {
+        writeFileSync(pkgPath, JSON.stringify(pkg, null, 4) + '\n');
+    }
+
+    return { name, changes };
+}
+
+console.log(`mode: ${opts.dry ? 'DRY RUN (no files written)' : 'APPLY (writing changes)'}, bump=${opts.bump}${opts.includeArchived ? ', including archived' : ''}`);
+
+const rootChanges = updateRootPackage();
+
+const templates = discoverTemplates();
+console.log(`\n== templates (${templates.length} discovered) ==`);
+let updated = 0;
+let skipped = 0;
+for (const name of templates) {
+    const result = updateTemplate(name);
+    if (result.skipped) {
+        skipped++;
+        continue;
+    }
+    updated++;
+    console.log(`${name}:`);
+    for (const c of result.changes) console.log(`  ${c}`);
+}
+
+console.log(`\n== summary ==`);
+console.log(`root dependency changes: ${rootChanges.length}`);
+console.log(`templates updated: ${updated}`);
+console.log(`templates skipped (archived): ${skipped}`);
+if (opts.dry) {
+    console.log('\nDry run only — rerun without --dry to write changes.');
+} else {
+    console.log('\nNext steps: npm install && npm run compile --workspaces --if-present && npm test');
+}

--- a/src/acceptance-of-delivery/logic/generated/concerto@1.0.0.ts
+++ b/src/acceptance-of-delivery/logic/generated/concerto@1.0.0.ts
@@ -18,12 +18,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
+import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
-import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -48,9 +48,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IContract | 
-IClause | 
-IState;
+export type AssetUnion = IState | 
+IContract | 
+IClause;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/acceptance-of-delivery/package.json
+++ b/src/acceptance-of-delivery/package.json
@@ -1,7 +1,7 @@
 {
     "name": "acceptance-of-delivery",
     "displayName": "Acceptance of Delivery",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause allows the receiver of goods to inspect them for a given time period after delivery.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/bill-of-lading/package.json
+++ b/src/bill-of-lading/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bill-of-lading",
     "displayName": "Bill of Lading",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Bill of Lading for transport of goods via ocean vessel",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/certificate-of-incorporation/package.json
+++ b/src/certificate-of-incorporation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "certificate-of-incorporation",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a sample Certificate of Incorporation.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/company-information/package.json
+++ b/src/company-information/package.json
@@ -1,7 +1,7 @@
 {
     "name": "company-information",
     "displayName": "Company Information",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Gather company information",
     "license": "Apache-2.0",
     "accordproject": {

--- a/src/contact-information/package.json
+++ b/src/contact-information/package.json
@@ -1,7 +1,7 @@
 {
     "name": "contact-information",
     "displayName": "Contact Information",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Gather contact information",
     "license": "Apache-2.0",
     "accordproject": {

--- a/src/copyright-license/package.json
+++ b/src/copyright-license/package.json
@@ -1,7 +1,7 @@
 {
     "name": "copyright-license",
     "displayName": "Copyright License",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause is a copyright license agreement.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/demandforecast/package.json
+++ b/src/demandforecast/package.json
@@ -1,7 +1,7 @@
 {
     "name": "demandforecast",
     "displayName": "Demand Forecast",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A sample demandforecast clause.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/docusign-connect/logic/generated/concerto@1.0.0.ts
+++ b/src/docusign-connect/logic/generated/concerto@1.0.0.ts
@@ -18,12 +18,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
-import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 import type {
 	IBinaryResource
 } from './org.accordproject.binary@0.2.0';
@@ -53,9 +53,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
+export type AssetUnion = IContract | 
 IClause | 
+IState | 
 IBinaryResource;
 
 export interface IParticipant extends IConcept {

--- a/src/docusign-connect/package.json
+++ b/src/docusign-connect/package.json
@@ -1,7 +1,7 @@
 {
     "name": "docusign-connect",
     "displayName": "Docusign Connect",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Counts events from DocuSign connect with a given envelope status.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/docusign-po-failure/logic/generated/concerto@1.0.0.ts
+++ b/src/docusign-po-failure/logic/generated/concerto@1.0.0.ts
@@ -5,13 +5,6 @@
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IDigitalMonetaryAmount,
-	DigitalCurrencyCode,
-	IMonetaryAmount,
-	CurrencyCode,
-	ICurrencyConversion
-} from './org.accordproject.money@0.3.0';
-import type {
 	Month,
 	Day,
 	TemporalUnit,
@@ -19,6 +12,13 @@ import type {
 	PeriodUnit,
 	IPeriod
 } from './org.accordproject.time@0.3.0';
+import type {
+	IDigitalMonetaryAmount,
+	DigitalCurrencyCode,
+	IMonetaryAmount,
+	CurrencyCode,
+	ICurrencyConversion
+} from './org.accordproject.money@0.3.0';
 import type {
 	EnvelopeStatusCode,
 	RecipientStatusCode,
@@ -59,11 +59,11 @@ export interface IConcept {
    $class: string;
 }
 
-export type ConceptUnion = IDigitalMonetaryAmount | 
+export type ConceptUnion = IDuration | 
+IPeriod | 
+IDigitalMonetaryAmount | 
 IMonetaryAmount | 
 ICurrencyConversion | 
-IDuration | 
-IPeriod | 
 IEnvelopeStatus | 
 IRecipient | 
 ICustomField | 

--- a/src/docusign-po-failure/package.json
+++ b/src/docusign-po-failure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "purchase-order-failure",
     "displayName": "Purchase Order Failure",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Issues credits for late purchase orders. Purchase orders sent via DocuSign must have the text recipient tabs with the following tab labels and validations: deliveryDate with Date validation, actualPrice with Numbers validation and currencyCode with no validation.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/empty-contract/logic/generated/concerto@1.0.0.ts
+++ b/src/empty-contract/logic/generated/concerto@1.0.0.ts
@@ -5,12 +5,12 @@
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
-import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -32,9 +32,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
-IClause;
+export type AssetUnion = IContract | 
+IClause | 
+IState;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/empty-contract/package.json
+++ b/src/empty-contract/package.json
@@ -1,7 +1,7 @@
 {
     "name": "empty-contract",
     "displayName": "Empty Contract",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is an empty contract template to get you started.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/empty/package.json
+++ b/src/empty/package.json
@@ -1,7 +1,7 @@
 {
     "name": "empty",
     "displayName": "Empty",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is an empty clause template to get you started.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/fixed-interests/logic/generated/concerto@1.0.0.ts
+++ b/src/fixed-interests/logic/generated/concerto@1.0.0.ts
@@ -14,12 +14,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
-import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -45,9 +45,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
-IClause;
+export type AssetUnion = IContract | 
+IClause | 
+IState;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/fixed-interests/package.json
+++ b/src/fixed-interests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fixed-interests",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A Fixed Interests Loan Clause, with a monthly Payment",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/fragile-goods/package.json
+++ b/src/fragile-goods/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fragile-goods",
     "displayName": "Fragile Goods",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause specifies penalties for shocks caused to a fragile package in transport.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/full-payment-upon-demand/logic/generated/concerto@1.0.0.ts
+++ b/src/full-payment-upon-demand/logic/generated/concerto@1.0.0.ts
@@ -14,12 +14,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
-import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -45,9 +45,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
-IClause;
+export type AssetUnion = IContract | 
+IClause | 
+IState;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/full-payment-upon-demand/package.json
+++ b/src/full-payment-upon-demand/package.json
@@ -1,7 +1,7 @@
 {
     "name": "full-payment-upon-demand",
     "displayName": "Full Payment Upon Demand",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a one-time full payment clause applicable on demand.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/helloworld/logic/generated/concerto@1.0.0.ts
+++ b/src/helloworld/logic/generated/concerto@1.0.0.ts
@@ -5,12 +5,12 @@
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
+import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
-import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -32,9 +32,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IContract | 
-IClause | 
-IState;
+export type AssetUnion = IState | 
+IContract | 
+IClause;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/helloworld/package.json
+++ b/src/helloworld/package.json
@@ -1,7 +1,7 @@
 {
     "name": "helloworld",
     "displayName": "Hello World",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is the Hello World of Accord Project Templates. Executing the clause will simply echo back the text that occurs after the string `Hello` prepended to text that is passed in the request.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/helloworldstate/package.json
+++ b/src/helloworldstate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "helloworldstate",
     "displayName": "Hello World State",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is the stateful Hello World of Accord Project Templates. Executing the clause will simply echo back the text that occurs after the string `Hello` prepended to text that is passed in the request along with the number of times the clause has been called.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/installment-sale/logic/generated/concerto@1.0.0.ts
+++ b/src/installment-sale/logic/generated/concerto@1.0.0.ts
@@ -17,12 +17,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
+import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
-import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -48,9 +48,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IContract | 
-IClause | 
-IState;
+export type AssetUnion = IState | 
+IContract | 
+IClause;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/installment-sale/package.json
+++ b/src/installment-sale/package.json
@@ -1,7 +1,7 @@
 {
     "name": "installment-sale",
     "displayName": "Installment Sale",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "description": "This is a clause for a simple installment sale.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/interest-rate-swap/logic/generated/concerto@1.0.0.ts
+++ b/src/interest-rate-swap/logic/generated/concerto@1.0.0.ts
@@ -17,12 +17,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
+import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
-import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -49,9 +49,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IContract | 
-IClause | 
-IState;
+export type AssetUnion = IState | 
+IContract | 
+IClause;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/interest-rate-swap/package.json
+++ b/src/interest-rate-swap/package.json
@@ -1,7 +1,7 @@
 {
     "name": "interest-rate-swap",
     "displayName": "Interest Rate Swap",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A simple ISDA Interest Rate Swap",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/ip-payment/package.json
+++ b/src/ip-payment/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ip-payment",
     "displayName": "IP Payment",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause is a payment clause for IP agreements, such as trademark or copyright licenses.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/latedeliveryandpenalty/logic/generated/concerto@1.0.0.ts
+++ b/src/latedeliveryandpenalty/logic/generated/concerto@1.0.0.ts
@@ -5,13 +5,6 @@
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IDigitalMonetaryAmount,
-	DigitalCurrencyCode,
-	IMonetaryAmount,
-	CurrencyCode,
-	ICurrencyConversion
-} from './org.accordproject.money@0.3.0';
-import type {
 	Month,
 	Day,
 	TemporalUnit,
@@ -19,6 +12,13 @@ import type {
 	PeriodUnit,
 	IPeriod
 } from './org.accordproject.time@0.3.0';
+import type {
+	IDigitalMonetaryAmount,
+	DigitalCurrencyCode,
+	IMonetaryAmount,
+	CurrencyCode,
+	ICurrencyConversion
+} from './org.accordproject.money@0.3.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -48,11 +48,11 @@ export interface IConcept {
    $class: string;
 }
 
-export type ConceptUnion = IDigitalMonetaryAmount | 
+export type ConceptUnion = IDuration | 
+IPeriod | 
+IDigitalMonetaryAmount | 
 IMonetaryAmount | 
-ICurrencyConversion | 
-IDuration | 
-IPeriod;
+ICurrencyConversion;
 
 export interface IAsset extends IConcept {
    $identifier: string;

--- a/src/latedeliveryandpenalty/package.json
+++ b/src/latedeliveryandpenalty/package.json
@@ -1,7 +1,7 @@
 {
     "name": "latedeliveryandpenalty",
     "displayName": "Late Delivery and Penalty",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A sample Late Delivery And Penalty clause.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/lateinvoicewithpayment/logic/generated/concerto@1.0.0.ts
+++ b/src/lateinvoicewithpayment/logic/generated/concerto@1.0.0.ts
@@ -5,13 +5,6 @@
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IDigitalMonetaryAmount,
-	DigitalCurrencyCode,
-	IMonetaryAmount,
-	CurrencyCode,
-	ICurrencyConversion
-} from './org.accordproject.money@0.3.0';
-import type {
 	Month,
 	Day,
 	TemporalUnit,
@@ -19,15 +12,22 @@ import type {
 	PeriodUnit,
 	IPeriod
 } from './org.accordproject.time@0.3.0';
+import type {
+	IDigitalMonetaryAmount,
+	DigitalCurrencyCode,
+	IMonetaryAmount,
+	CurrencyCode,
+	ICurrencyConversion
+} from './org.accordproject.money@0.3.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
-import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
 import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -48,19 +48,19 @@ export interface IConcept {
    $class: string;
 }
 
-export type ConceptUnion = IDigitalMonetaryAmount | 
+export type ConceptUnion = IDuration | 
+IPeriod | 
+IDigitalMonetaryAmount | 
 IMonetaryAmount | 
-ICurrencyConversion | 
-IDuration | 
-IPeriod;
+ICurrencyConversion;
 
 export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
-IClause;
+export type AssetUnion = IContract | 
+IClause | 
+IState;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/lateinvoicewithpayment/package.json
+++ b/src/lateinvoicewithpayment/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lateinvoicewithpayment",
     "displayName": "Late Invoice with Payment",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A sample Late invoice clause which emits a payment obligation.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/minilatedeliveryandpenalty/logic/generated/concerto@1.0.0.ts
+++ b/src/minilatedeliveryandpenalty/logic/generated/concerto@1.0.0.ts
@@ -5,13 +5,6 @@
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IDigitalMonetaryAmount,
-	DigitalCurrencyCode,
-	IMonetaryAmount,
-	CurrencyCode,
-	ICurrencyConversion
-} from './org.accordproject.money@0.3.0';
-import type {
 	Month,
 	Day,
 	TemporalUnit,
@@ -19,6 +12,13 @@ import type {
 	PeriodUnit,
 	IPeriod
 } from './org.accordproject.time@0.3.0';
+import type {
+	IDigitalMonetaryAmount,
+	DigitalCurrencyCode,
+	IMonetaryAmount,
+	CurrencyCode,
+	ICurrencyConversion
+} from './org.accordproject.money@0.3.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -45,11 +45,11 @@ export interface IConcept {
    $class: string;
 }
 
-export type ConceptUnion = IDigitalMonetaryAmount | 
+export type ConceptUnion = IDuration | 
+IPeriod | 
+IDigitalMonetaryAmount | 
 IMonetaryAmount | 
-ICurrencyConversion | 
-IDuration | 
-IPeriod;
+ICurrencyConversion;
 
 export interface IAsset extends IConcept {
    $identifier: string;

--- a/src/minilatedeliveryandpenalty/package.json
+++ b/src/minilatedeliveryandpenalty/package.json
@@ -1,7 +1,7 @@
 {
     "name": "minilatedeliveryandpenalty",
     "displayName": "Mini Late Delivery And Penalty",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A simplified late delivery and penalty clause.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/payment-upon-delivery/package.json
+++ b/src/payment-upon-delivery/package.json
@@ -1,7 +1,7 @@
 {
     "name": "payment-upon-delivery",
     "displayName": "Payment Upon Delivery",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a one time payment contract upon acceptance of delivery.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/payment-upon-iot/logic/generated/concerto@1.0.0.ts
+++ b/src/payment-upon-iot/logic/generated/concerto@1.0.0.ts
@@ -17,12 +17,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
+import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
-import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -48,9 +48,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IContract | 
-IClause | 
-IState;
+export type AssetUnion = IState | 
+IContract | 
+IClause;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/payment-upon-iot/package.json
+++ b/src/payment-upon-iot/package.json
@@ -1,7 +1,7 @@
 {
     "name": "payment-upon-iot",
     "displayName": "Payment Upon IoT",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a payment contract that pays out a fixed amount each time a button is pressed.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/payment-upon-signature/logic/generated/concerto@1.0.0.ts
+++ b/src/payment-upon-signature/logic/generated/concerto@1.0.0.ts
@@ -14,12 +14,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
-import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -45,9 +45,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
-IClause;
+export type AssetUnion = IContract | 
+IClause | 
+IState;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/payment-upon-signature/package.json
+++ b/src/payment-upon-signature/package.json
@@ -1,7 +1,7 @@
 {
     "name": "payment-upon-signature",
     "displayName": "Payment Upon Signature",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a generic payment clause applicable to any type of contract that requires some payment at the time of signature.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/perishable-goods/logic/generated/concerto@1.0.0.ts
+++ b/src/perishable-goods/logic/generated/concerto@1.0.0.ts
@@ -18,12 +18,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
+import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
-import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -50,9 +50,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IContract | 
-IClause | 
-IState;
+export type AssetUnion = IState | 
+IContract | 
+IClause;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/perishable-goods/package.json
+++ b/src/perishable-goods/package.json
@@ -1,7 +1,7 @@
 {
     "name": "perishable-goods",
     "displayName": "Perishable Goods",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause specifies penalties if the transport conditions (temperature and humidity) for a package are breached.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/project-information/package.json
+++ b/src/project-information/package.json
@@ -1,7 +1,7 @@
 {
     "name": "project-information",
     "displayName": "Project Information",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Gather project information",
     "license": "Apache-2.0",
     "accordproject": {

--- a/src/promissory-note/package.json
+++ b/src/promissory-note/package.json
@@ -1,7 +1,7 @@
 {
     "name": "promissory-note",
     "displayName": "Promissory Note",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A promissory note",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/rental-deposit/package.json
+++ b/src/rental-deposit/package.json
@@ -1,7 +1,7 @@
 {
     "name": "rental-deposit",
     "displayName": "Rental Deposit",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause specifies how a rental deposit is refunded based on inspection.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/roommate/package.json
+++ b/src/roommate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "roommate",
     "displayName": "Roommate Agreement",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This contract is a simple roommate agreement.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/saft/package.json
+++ b/src/saft/package.json
@@ -1,7 +1,7 @@
 {
     "name": "saft",
     "displayName": "SAFT",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "The SAFT contract is a futures contract where a person invests in a company in exchange for receiving utility tokens that may be used when a product launches.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/safte/logic/generated/concerto@1.0.0.ts
+++ b/src/safte/logic/generated/concerto@1.0.0.ts
@@ -14,12 +14,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
-import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -45,9 +45,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
-IClause;
+export type AssetUnion = IContract | 
+IClause | 
+IState;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/safte/package.json
+++ b/src/safte/package.json
@@ -1,7 +1,7 @@
 {
     "name": "safte",
     "displayName": "SAFTE",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "The SAFTE contract is a futures contract where a person invests in a company in exchange for receiving either utility tokens that may be used when a product launches or equity in the company.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/servicelevelagreement/package.json
+++ b/src/servicelevelagreement/package.json
@@ -1,7 +1,7 @@
 {
     "name": "servicelevelagreement",
     "displayName": "Service Level Agreement",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A service level agreement that gives invoice credit based on service availability.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/supply-agreement-loc/logic/generated/concerto@1.0.0.ts
+++ b/src/supply-agreement-loc/logic/generated/concerto@1.0.0.ts
@@ -8,13 +8,6 @@ import type {
 	ISensorReadingData
 } from './org.accordproject.supplyagreementloc@0.2.0';
 import type {
-	IDigitalMonetaryAmount,
-	DigitalCurrencyCode,
-	IMonetaryAmount,
-	CurrencyCode,
-	ICurrencyConversion
-} from './org.accordproject.money@0.3.0';
-import type {
 	Month,
 	Day,
 	TemporalUnit,
@@ -22,15 +15,22 @@ import type {
 	PeriodUnit,
 	IPeriod
 } from './org.accordproject.time@0.3.0';
+import type {
+	IDigitalMonetaryAmount,
+	DigitalCurrencyCode,
+	IMonetaryAmount,
+	CurrencyCode,
+	ICurrencyConversion
+} from './org.accordproject.money@0.3.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
-import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -49,19 +49,19 @@ export interface IConcept {
 }
 
 export type ConceptUnion = ISensorReadingData | 
+IDuration | 
+IPeriod | 
 IDigitalMonetaryAmount | 
 IMonetaryAmount | 
-ICurrencyConversion | 
-IDuration | 
-IPeriod;
+ICurrencyConversion;
 
 export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IContract | 
-IClause | 
-IState;
+export type AssetUnion = IState | 
+IContract | 
+IClause;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/supply-agreement-loc/package.json
+++ b/src/supply-agreement-loc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "supply-agreement-loc",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Supply agreement with letter of credit and sensor reading validation",
     "author": "John Carpenter",
     "license": "Apache-2.0",

--- a/src/supplyagreement-perishable-goods/package.json
+++ b/src/supplyagreement-perishable-goods/package.json
@@ -1,7 +1,7 @@
 {
     "name": "supplyagreement-perishable-goods",
     "displayName": "Supply Agreement Perishable Goods",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This supply agreement specifies penalties if the transport conditions (temperature and humidity) for a package are breached.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/supplyagreement/logic/generated/concerto@1.0.0.ts
+++ b/src/supplyagreement/logic/generated/concerto@1.0.0.ts
@@ -22,12 +22,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
-import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -59,9 +59,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
-IClause;
+export type AssetUnion = IContract | 
+IClause | 
+IState;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/supplyagreement/package.json
+++ b/src/supplyagreement/package.json
@@ -1,7 +1,7 @@
 {
     "name": "supplyagreement",
     "displayName": "Supply Agreement",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A sample supply agreement.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/volumediscount/logic/generated/concerto@1.0.0.ts
+++ b/src/volumediscount/logic/generated/concerto@1.0.0.ts
@@ -14,12 +14,12 @@ import type {
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
-	IState
-} from './org.accordproject.runtime@0.2.0';
-import type {
 	IContract,
 	IClause
 } from './org.accordproject.contract@0.2.0';
+import type {
+	IState
+} from './org.accordproject.runtime@0.2.0';
 
 // Warning: Beware of circular dependencies when modifying these imports
 import type {
@@ -45,9 +45,9 @@ export interface IAsset extends IConcept {
    $identifier: string;
 }
 
-export type AssetUnion = IState | 
-IContract | 
-IClause;
+export type AssetUnion = IContract | 
+IClause | 
+IState;
 
 export interface IParticipant extends IConcept {
    $identifier: string;

--- a/src/volumediscount/package.json
+++ b/src/volumediscount/package.json
@@ -1,7 +1,7 @@
 {
     "name": "volumediscount",
     "displayName": "Volume Discount",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A sample volume discount contract.",
     "author": "Accord Project",
     "license": "Apache-2.0",


### PR DESCRIPTION
### Changes
Adds `scripts/upgrade-cicero-v2.mjs` and applies it to the 37 active templates (archived templates left untouched).

- `scripts/upgrade-cicero-v2.mjs`: reusable script that bumps `@accordproject/*` deps in the root `package.json`, normalizes `accordproject.cicero` to `^2.0.0` per active template, drops any stray legacy `engines` block, and patch-bumps each active template's own `version`. Supports `--dry`, `--template <list>`, `--bump patch|minor|major`, `--include-archived`.
- Applied result: root `package.json` deps bumped —
  - `cicero-core` 2.0.0 → 2.1.1
  - `concerto-cli` 4.0.1 → 4.0.2
  - `concerto-core` 4.1.4 → 4.1.5
  - `concerto-codegen` 4.1.3 → 5.1.0 (**major** — pulled in transitively by `concerto-cli`, see verification below)
  - `concerto-util` 4.1.4 → 4.1.5
  - `markdown-cicero`, `markdown-html`, `template-engine` already latest, unchanged
- Each of the 37 active templates: `version` patch-bumped (e.g. `1.0.0` → `1.0.1`), `logic/generated/` recompiled with the new toolchain.
- `package-lock.json` updated via `npm install`.
- Archived templates (`package.json` `archived: true`) are completely untouched — no `package.json`, `logic/generated`, or lockfile entries for them changed.

### Verification
Before applying for real, I ran the full upgrade in a disposable local worktree and compared against a pre-upgrade baseline:
- `npm run compile --workspaces --if-present` — all 57 templates compile clean before and after
- `logic/generated/` diff is **cosmetic only** — member reordering inside generated union types (e.g. `AssetUnion`), no type/shape changes, despite the `concerto-codegen` major version bump
- `npm run test --workspaces --if-present` — all pass, identical to baseline
- `npm run test:render` — **113 passed, 3 expected fail, exit 0 — identical to baseline** (the existing `expectedFailures` set in `test/render.test.mjs` is unaffected)

Full verification notes are in the PR comment thread below.

### Flags
- `npm audit` vulnerability count moved from 88 → 104 after the lockfile update — appears to be transitive churn from the `concerto-codegen` major bump's own dependency tree, not something the script introduces directly. Worth a glance, didn't block anything above.
- Root `engines.node` (`>=22`) intentionally left unchanged — none of the upgraded packages declare an `engines` requirement that forces a bump.

### Author Checklist
- [x] Commits messages follow [AP format](https://github.com/accordproject/techdocs/blob/master/DEVELOPERS.md#commit-message-format)
- [x] Vital features and changes captured in unit and/or integration tests (existing `npm test` / `npm run test:render` suites, run against both baseline and upgraded state)
- [ ] Extend the documentation, if necessary
