### PR TITLE
[fix]: Update the model.cto files to emit events with Obligation type

### DIFF
--- a/src/certificate-of-incorporation/model/model.cto
+++ b/src/certificate-of-incorporation/model/model.cto
@@ -1,10 +1,10 @@
 namespace org.accordproject.certificateofincorporation@0.1.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.signature@0.3.0.ContractSigned from https://models.accordproject.org/signature/signature@0.3.0.cto
 
-event IncorporationEvent {
+event IncorporationEvent extends Obligation {
   o String companyName
   o DateTime incorporationDate
   o Long authorizedShareCapital
@@ -12,7 +12,7 @@ event IncorporationEvent {
 }
 
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String companyName
   o String incorporationState
   o String streetAddress

--- a/src/certificate-of-incorporation/package.json
+++ b/src/certificate-of-incorporation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "certificate-of-incorporation",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "This is a sample Certificate of Incorporation.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/certificate-of-incorporation/sample.json
+++ b/src/certificate-of-incorporation/sample.json
@@ -16,5 +16,5 @@
   "incorporatorState": "MD",
   "incorporatorZip": "21201",
   "$identifier": "07a4f261-dbb1-4d2e-bcab-79cff92c4aa4",
-  "clauseId": "07a4f261-dbb1-4d2e-bcab-79cff92c4aa4"
+  "contractId": "07a4f261-dbb1-4d2e-bcab-79cff92c4aa4"
 }

--- a/src/copyright-license/model/model.cto
+++ b/src/copyright-license/model/model.cto
@@ -1,7 +1,7 @@
 namespace org.accordproject.copyrightlicense@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.{Clause,Contract} from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
 /* Requesting a payment */
@@ -13,7 +13,7 @@ transaction PayOut extends Response {
   o MonetaryAmount amount
 }
 
-event PaymentObligationEvent {
+event PaymentObligationEvent extends Obligation {
   o MonetaryAmount amount
   o String description
 }

--- a/src/copyright-license/model/model.cto
+++ b/src/copyright-license/model/model.cto
@@ -1,7 +1,7 @@
 namespace org.accordproject.copyrightlicense@0.2.0
 
 import org.accordproject.contract@0.2.0.{Clause,Contract} from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request, Response, Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
 /* Requesting a payment */
@@ -26,7 +26,7 @@ asset PaymentClause extends Clause {
 
 /* The template model */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   /* the effective date */
   o DateTime effectiveDate
 

--- a/src/copyright-license/package.json
+++ b/src/copyright-license/package.json
@@ -1,7 +1,7 @@
 {
     "name": "copyright-license",
     "displayName": "Copyright License",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause is a copyright license agreement.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/copyright-license/sample.json
+++ b/src/copyright-license/sample.json
@@ -1,11 +1,11 @@
 {
   "$class": "org.accordproject.copyrightlicense@0.2.0.TemplateModel",
   "effectiveDate": "2018-01-01T01:00:00.000+01:00",
-  "licensee": "resource:org.accordproject.party@0.2.0.Party#Me",
+  "licensee": "Me",
   "licenseeState": "NY",
   "licenseeEntityType": "Company",
   "licenseeAddress": "1 Broadway",
-  "licensor": "resource:org.accordproject.party@0.2.0.Party#Myself",
+  "licensor": "Myself",
   "licensorState": "NY",
   "licensorEntityType": "Company",
   "licensorAddress": "2 Broadway",
@@ -21,9 +21,9 @@
       "currencyCode": "USD"
     },
     "paymentProcedure": "bank transfer",
-    "contractId": "26149239-4c42-4d57-b503-d5870d2337a8",
+    "clauseId": "26149239-4c42-4d57-b503-d5870d2337a8",
     "$identifier": "26149239-4c42-4d57-b503-d5870d2337a8"
   },
   "$identifier": "ed39610c-5572-4381-b2ac-f7d75044edbc",
-  "clauseId": "ed39610c-5572-4381-b2ac-f7d75044edbc"
+  "contractId": "ed39610c-5572-4381-b2ac-f7d75044edbc"
 }

--- a/src/copyright-license/sample.json
+++ b/src/copyright-license/sample.json
@@ -21,7 +21,7 @@
       "currencyCode": "USD"
     },
     "paymentProcedure": "bank transfer",
-    "clauseId": "26149239-4c42-4d57-b503-d5870d2337a8",
+    "contractId": "26149239-4c42-4d57-b503-d5870d2337a8",
     "$identifier": "26149239-4c42-4d57-b503-d5870d2337a8"
   },
   "$identifier": "ed39610c-5572-4381-b2ac-f7d75044edbc",

--- a/src/docusign-connect/model/model.cto
+++ b/src/docusign-connect/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.docusignconnect@0.1.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import com.docusign.connect@0.4.0.DocuSignEnvelopeInformation from https://models.accordproject.org/docusign/connect@0.4.0.cto
 import com.docusign.connect@0.4.0.EnvelopeStatusCode from https://models.accordproject.org/docusign/connect@0.4.0.cto
@@ -23,7 +23,7 @@ asset DocuSignEnvelopeCounterState extends State {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   /**
    * The status of the envelope to count
    */

--- a/src/docusign-connect/package.json
+++ b/src/docusign-connect/package.json
@@ -1,7 +1,7 @@
 {
     "name": "docusign-connect",
     "displayName": "Docusign Connect",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Counts events from DocuSign connect with a given envelope status.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/docusign-connect/sample.json
+++ b/src/docusign-connect/sample.json
@@ -2,5 +2,5 @@
   "$class": "org.accordproject.docusignconnect@0.1.0.TemplateModel",
   "status": "Completed",
   "$identifier": "94da90f6-5166-4ba7-8675-e2777407d464",
-  "clauseId": "94da90f6-5166-4ba7-8675-e2777407d464"
+  "contractId": "94da90f6-5166-4ba7-8675-e2777407d464"
 }

--- a/src/docusign-po-failure/model/model.cto
+++ b/src/docusign-po-failure/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.docusignpofailure@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.time@0.3.0.Duration from https://models.accordproject.org/time@0.3.0.cto
 import com.docusign.connect@0.4.0.DocuSignEnvelopeInformation from https://models.accordproject.org/docusign/connect@0.4.0.cto
@@ -21,7 +21,7 @@ asset PurchaseOrderFailureState extends State {
 }
 
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String buyerName
 
   o Duration lateOne

--- a/src/docusign-po-failure/package.json
+++ b/src/docusign-po-failure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "purchase-order-failure",
     "displayName": "Purchase Order Failure",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Issues credits for late purchase orders. Purchase orders sent via DocuSign must have the text recipient tabs with the following tab labels and validations: deliveryDate with Date validation, actualPrice with Numbers validation and currencyCode with no validation.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/docusign-po-failure/sample.json
+++ b/src/docusign-po-failure/sample.json
@@ -33,6 +33,6 @@
     "currencyCode": "USD"
   },
   "repeatedFailureCompensationCurrency": "USD",
-  "clauseId": "d3e3a1c4-7f2b-4e6a-9c8d-1a2b3c4d5e6f",
+  "contractId": "d3e3a1c4-7f2b-4e6a-9c8d-1a2b3c4d5e6f",
   "$identifier": "d3e3a1c4-7f2b-4e6a-9c8d-1a2b3c4d5e6f"
 }

--- a/src/eat-apples/model/model.cto
+++ b/src/eat-apples/model/model.cto
@@ -1,7 +1,7 @@
 namespace org.accordproject.eatapples@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
 transaction Food extends Request {
@@ -13,13 +13,13 @@ transaction Outcome extends Response {
   o String notice
 }
 
-event Bill {
+event Bill extends Obligation {
   o String billTo
   o MonetaryAmount amount
 }
 
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String employee
   o String company
   o Double tax

--- a/src/eat-apples/package.json
+++ b/src/eat-apples/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eat-apples",
     "displayName": "Eat Apples",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a clause enforcing healthy eating habits in employees.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/eat-apples/sample.json
+++ b/src/eat-apples/sample.json
@@ -3,6 +3,6 @@
   "employee": "Dan",
   "company": "ACME",
   "tax": 4.5,
-  "clauseId": "0956261f-a7be-468d-b2dd-809c22fbc9c2",
+  "contractId": "0956261f-a7be-468d-b2dd-809c22fbc9c2",
   "$identifier": "0956261f-a7be-468d-b2dd-809c22fbc9c2"
 }

--- a/src/fragile-goods/model/model.cto
+++ b/src/fragile-goods/model/model.cto
@@ -1,7 +1,7 @@
 namespace org.accordproject.fragilegoods@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.time@0.3.0.{Duration,TemporalUnit} from https://models.accordproject.org/time@0.3.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -25,7 +25,7 @@ transaction PayOut extends Response {
   o MonetaryAmount paymentAmount
 }
 
-event FragileGoodsEvent {
+event FragileGoodsEvent extends Obligation {
   o MonetaryAmount paymentAmount
 }
 
@@ -33,7 +33,7 @@ event FragileGoodsEvent {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String seller
   o String buyer
   o MonetaryAmount deliveryPrice

--- a/src/fragile-goods/package.json
+++ b/src/fragile-goods/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fragile-goods",
     "displayName": "Fragile Goods",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause specifies penalties for shocks caused to a fragile package in transport.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/fragile-goods/sample.json
+++ b/src/fragile-goods/sample.json
@@ -25,5 +25,5 @@
     "currencyCode": "USD"
   },
   "$identifier": "aea19c25-de58-420b-9748-b8ac0d9668c4",
-  "clauseId": "aea19c25-de58-420b-9748-b8ac0d9668c4"
+  "contractId": "aea19c25-de58-420b-9748-b8ac0d9668c4"
 }

--- a/src/full-payment-upon-demand/model/model.cto
+++ b/src/full-payment-upon-demand/model/model.cto
@@ -1,12 +1,12 @@
 namespace org.accordproject.fullpaymentupondemand@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
 // Template model
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String buyer
   o String seller
   o MonetaryAmount amount

--- a/src/full-payment-upon-demand/package.json
+++ b/src/full-payment-upon-demand/package.json
@@ -1,7 +1,7 @@
 {
     "name": "full-payment-upon-demand",
     "displayName": "Full Payment Upon Demand",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a one-time full payment clause applicable on demand.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/full-payment-upon-demand/sample.json
+++ b/src/full-payment-upon-demand/sample.json
@@ -8,5 +8,5 @@
     "currencyCode": "EUR"
   },
   "$identifier": "c8648553-53af-400d-bf8c-f2102a17c28c",
-  "clauseId": "c8648553-53af-400d-bf8c-f2102a17c28c"
+  "contractId": "c8648553-53af-400d-bf8c-f2102a17c28c"
 }

--- a/src/full-payment-upon-signature/model/model.cto
+++ b/src/full-payment-upon-signature/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.fullpaymentupondsignature@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -8,7 +8,7 @@ import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordpr
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String buyer
   o String seller
   o MonetaryAmount amount

--- a/src/full-payment-upon-signature/package.json
+++ b/src/full-payment-upon-signature/package.json
@@ -1,7 +1,7 @@
 {
     "name": "full-payment-upon-signature",
     "displayName": "Full Payment Upon Signature",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a one-time full payment clause applicable at the signature of the contract.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/full-payment-upon-signature/sample.json
+++ b/src/full-payment-upon-signature/sample.json
@@ -8,5 +8,5 @@
     "currencyCode": "USD"
   },
   "$identifier": "eb47cf04-9706-435b-91f9-3da5a8b7dfb7",
-  "clauseId": "eb47cf04-9706-435b-91f9-3da5a8b7dfb7"
+  "contractId": "eb47cf04-9706-435b-91f9-3da5a8b7dfb7"
 }

--- a/src/installment-sale/model/model.cto
+++ b/src/installment-sale/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.installmentsale@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -40,7 +40,7 @@ event InstallmentSalePaymentEvent extends Obligation {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String BUYER
   o String SELLER
   o MonetaryAmount INITIAL_DUE

--- a/src/installment-sale/package.json
+++ b/src/installment-sale/package.json
@@ -1,7 +1,7 @@
 {
     "name": "installment-sale",
     "displayName": "Installment Sale",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "description": "This is a clause for a simple installment sale.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/installment-sale/sample.json
+++ b/src/installment-sale/sample.json
@@ -25,5 +25,5 @@
   },
   "FIRST_MONTH": 3,
   "$identifier": "ae1b4bc2-e558-47d2-9694-39ce42819783",
-  "clauseId": "ae1b4bc2-e558-47d2-9694-39ce42819783"
+  "contractId": "ae1b4bc2-e558-47d2-9694-39ce42819783"
 }

--- a/src/lateinvoicewithpayment/model/model.cto
+++ b/src/lateinvoicewithpayment/model/model.cto
@@ -1,7 +1,7 @@
 namespace org.accordproject.lateinvoicewithpayment@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.time@0.3.0.{Duration,TemporalUnit} from https://models.accordproject.org/time@0.3.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -11,7 +11,7 @@ import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordpr
  * must generate from input source text.
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   /**
    * If the invoice deliver date  >= termination date then the buyer does not have to pay
    */
@@ -40,7 +40,7 @@ transaction LateInvoiceResponse extends Response {
 }
 
 // Event emitted when payment is required
-event PaymentObligationEvent {
+event PaymentObligationEvent extends Obligation {
   o MonetaryAmount amount
   o String description
 }

--- a/src/lateinvoicewithpayment/package.json
+++ b/src/lateinvoicewithpayment/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lateinvoicewithpayment",
     "displayName": "Late Invoice with Payment",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A sample Late invoice clause which emits a payment obligation.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/lateinvoicewithpayment/sample.json
+++ b/src/lateinvoicewithpayment/sample.json
@@ -8,5 +8,5 @@
   "purchaser": "resource:org.accordproject.party@0.2.0.Party#Betty%20Buyer",
   "supplier": "resource:org.accordproject.party@0.2.0.Party#Steve%20Seller",
   "$identifier": "a6d1af73-448e-4892-a357-b11322a22532",
-  "clauseId": "a6d1af73-448e-4892-a357-b11322a22532"
+  "contractId": "a6d1af73-448e-4892-a357-b11322a22532"
 }

--- a/src/minilatedeliveryandpenalty-payment/model/model.cto
+++ b/src/minilatedeliveryandpenalty-payment/model/model.cto
@@ -1,7 +1,7 @@
 namespace org.accordproject.minilatedeliveryandpenaltypayment@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.time@0.3.0.{Duration,TemporalUnit} from https://models.accordproject.org/time@0.3.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -16,13 +16,13 @@ transaction LateResponse extends Response {
   o Boolean buyerMayTerminate
 }
 
-event PaymentObligationEvent {
+event PaymentObligationEvent extends Obligation {
   o MonetaryAmount amount
   o String description
 }
 
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String buyer
   o String seller
   o Duration penaltyDuration

--- a/src/minilatedeliveryandpenalty-payment/package.json
+++ b/src/minilatedeliveryandpenalty-payment/package.json
@@ -1,7 +1,7 @@
 {
     "name": "minilatedeliveryandpenalty-payment",
     "displayName": "Mini-Late Delivery and Penalty Payment",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A Late Delivery And Penalty (Mini, Capped, with Payment)",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/minilatedeliveryandpenalty-payment/sample.json
+++ b/src/minilatedeliveryandpenalty-payment/sample.json
@@ -15,5 +15,5 @@
     "unit": "days"
   },
   "$identifier": "7f0ce5a1-2de3-4ae5-96dd-2da0449c1ff5",
-  "clauseId": "7f0ce5a1-2de3-4ae5-96dd-2da0449c1ff5"
+  "contractId": "7f0ce5a1-2de3-4ae5-96dd-2da0449c1ff5"
 }

--- a/src/one-time-payment-tr/model/model.cto
+++ b/src/one-time-payment-tr/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.onetimepaymenttr@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -8,7 +8,7 @@ import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordpr
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String buyer
   o String seller
   o MonetaryAmount totalPurchasePrice

--- a/src/one-time-payment-tr/package.json
+++ b/src/one-time-payment-tr/package.json
@@ -1,7 +1,7 @@
 {
     "name": "one-time-payment-tr",
     "displayName": "One Time Payment (TR)",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is an Full Payment Upon Signature Template prepared in Turkish Language.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/one-time-payment-tr/sample.json
+++ b/src/one-time-payment-tr/sample.json
@@ -8,5 +8,5 @@
     "currencyCode": "TRY"
   },
   "$identifier": "600ed083-59c4-4208-a8ba-8b9967547df1",
-  "clauseId": "600ed083-59c4-4208-a8ba-8b9967547df1"
+  "contractId": "600ed083-59c4-4208-a8ba-8b9967547df1"
 }

--- a/src/payment-upon-delivery/model/model.cto
+++ b/src/payment-upon-delivery/model/model.cto
@@ -1,14 +1,14 @@
 namespace org.accordproject.paymentupondelivery@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
 /**
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String buyer
   o String seller
   o MonetaryAmount costOfGoods
@@ -22,7 +22,7 @@ transaction DeliveryAcceptedResponse extends Response {
 }
 
 // Event emitted when a payment obligation is triggered
-event PaymentObligationEvent {
+event PaymentObligationEvent extends Obligation {
   o MonetaryAmount amount
   o String description
 }

--- a/src/payment-upon-delivery/package.json
+++ b/src/payment-upon-delivery/package.json
@@ -1,7 +1,7 @@
 {
     "name": "payment-upon-delivery",
     "displayName": "Payment Upon Delivery",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a one time payment contract upon acceptance of delivery.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/payment-upon-delivery/sample.json
+++ b/src/payment-upon-delivery/sample.json
@@ -13,5 +13,5 @@
     "currencyCode": "USD"
   },
   "$identifier": "14a1a72f-99da-4d76-947d-d62b26e98c68",
-  "clauseId": "14a1a72f-99da-4d76-947d-d62b26e98c68"
+  "contractId": "14a1a72f-99da-4d76-947d-d62b26e98c68"
 }

--- a/src/payment-upon-iot/model/model.cto
+++ b/src/payment-upon-iot/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.paymentuponiot@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -74,7 +74,7 @@ asset CounterState extends State {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String buyer
   o String seller
   o MonetaryAmount amountPerUnit

--- a/src/payment-upon-iot/package.json
+++ b/src/payment-upon-iot/package.json
@@ -1,7 +1,7 @@
 {
     "name": "payment-upon-iot",
     "displayName": "Payment Upon IoT",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a payment contract that pays out a fixed amount each time a button is pressed.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/payment-upon-iot/sample.json
+++ b/src/payment-upon-iot/sample.json
@@ -9,5 +9,5 @@
   },
   "paymentCount": 5,
   "$identifier": "4fdf51f3-d431-400a-b38b-3e37c83e6cea",
-  "clauseId": "4fdf51f3-d431-400a-b38b-3e37c83e6cea"
+  "contractId": "4fdf51f3-d431-400a-b38b-3e37c83e6cea"
 }

--- a/src/payment-upon-signature/model/model.cto
+++ b/src/payment-upon-signature/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.paymentuponssignature@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -8,7 +8,7 @@ import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordpr
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String buyer
   o String seller
   o MonetaryAmount amount

--- a/src/payment-upon-signature/package.json
+++ b/src/payment-upon-signature/package.json
@@ -1,7 +1,7 @@
 {
     "name": "payment-upon-signature",
     "displayName": "Payment Upon Signature",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This is a generic payment clause applicable to any type of contract that requires some payment at the time of signature.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/payment-upon-signature/sample.json
+++ b/src/payment-upon-signature/sample.json
@@ -8,5 +8,5 @@
     "currencyCode": "USD"
   },
   "$identifier": "86070b3c-23db-4091-9bc5-704148c12668",
-  "clauseId": "86070b3c-23db-4091-9bc5-704148c12668"
+  "contractId": "86070b3c-23db-4091-9bc5-704148c12668"
 }

--- a/src/perishable-goods/model/model.cto
+++ b/src/perishable-goods/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.perishablegoods@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -61,7 +61,7 @@ asset PerishableGoodsState extends State {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String grower
   o String importer
   o String shipmentId

--- a/src/perishable-goods/package.json
+++ b/src/perishable-goods/package.json
@@ -1,7 +1,7 @@
 {
     "name": "perishable-goods",
     "displayName": "Perishable Goods",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause specifies penalties if the transport conditions (temperature and humidity) for a package are breached.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/perishable-goods/sample.json
+++ b/src/perishable-goods/sample.json
@@ -21,5 +21,5 @@
   "maxHumidity": 90,
   "penaltyFactor": 0.2,
   "$identifier": "46467b65-22e0-40cc-900a-0f75dcc366f4",
-  "clauseId": "46467b65-22e0-40cc-900a-0f75dcc366f4"
+  "contractId": "46467b65-22e0-40cc-900a-0f75dcc366f4"
 }

--- a/src/rental-deposit-with/model/model.cto
+++ b/src/rental-deposit-with/model/model.cto
@@ -1,7 +1,7 @@
 namespace org.accordproject.rentaldepositwith@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 import org.accordproject.time@0.3.0.{Period} from https://models.accordproject.org/time@0.3.0.cto
 
@@ -32,7 +32,7 @@ transaction PropertyInspectionResponse extends Response {
   o MonetaryAmount balance
 }
 
-event RentalDepositPaymentEvent {
+event RentalDepositPaymentEvent extends Obligation {
   o MonetaryAmount amount
   o String description
 }
@@ -41,7 +41,7 @@ event RentalDepositPaymentEvent {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o RentalParty tenant
   o RentalParty landlord
   o MonetaryAmount depositAmount

--- a/src/rental-deposit-with/package.json
+++ b/src/rental-deposit-with/package.json
@@ -1,7 +1,7 @@
 {
     "name": "rental-deposit-with",
     "displayName": "Rental Deposit (Inlined)",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This clause specifies how a rental deposit is refunded based on inspection. (using with)",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/rental-deposit-with/sample.json
+++ b/src/rental-deposit-with/sample.json
@@ -33,5 +33,5 @@
   },
   "exhibit": "Schedule A",
   "$identifier": "81b1697a-f120-476c-a3d3-6ce760c1bffb",
-  "clauseId": "81b1697a-f120-476c-a3d3-6ce760c1bffb"
+  "contractId": "81b1697a-f120-476c-a3d3-6ce760c1bffb"
 }

--- a/src/rental-deposit/model/model.cto
+++ b/src/rental-deposit/model/model.cto
@@ -1,7 +1,7 @@
 namespace org.accordproject.rentaldeposit@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 import org.accordproject.time@0.3.0.{Period} from https://models.accordproject.org/time@0.3.0.cto
 
@@ -24,7 +24,7 @@ transaction PropertyInspectionResponse extends Response {
   o MonetaryAmount balance
 }
 
-event RentalDepositPaymentEvent {
+event RentalDepositPaymentEvent extends Obligation {
   o MonetaryAmount amount
   o String description
 }
@@ -33,7 +33,7 @@ event RentalDepositPaymentEvent {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o String tenant
   o String landlord
   o MonetaryAmount depositAmount

--- a/src/rental-deposit/package.json
+++ b/src/rental-deposit/package.json
@@ -1,7 +1,7 @@
 {
     "name": "rental-deposit",
     "displayName": "Rental Deposit",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "This clause specifies how a rental deposit is refunded based on inspection.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/rental-deposit/sample.json
+++ b/src/rental-deposit/sample.json
@@ -23,5 +23,5 @@
   },
   "exhibit": "Schedule A",
   "$identifier": "27662374-a272-49c1-bf7c-a329d1ddbdf1",
-  "clauseId": "27662374-a272-49c1-bf7c-a329d1ddbdf1"
+  "contractId": "27662374-a272-49c1-bf7c-a329d1ddbdf1"
 }

--- a/src/servicelevelagreement/model/model.cto
+++ b/src/servicelevelagreement/model/model.cto
@@ -1,11 +1,11 @@
 namespace org.accordproject.servicelevelagreement@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o Integer paymentPeriod
   o Double monthlyCapPercentage
   o Double yearlyCapPercentage
@@ -28,7 +28,7 @@ transaction InvoiceCredit extends Response {
   o MonetaryAmount monthlyCredit
 }
 
-event ServiceCreditPaymentEvent {
+event ServiceCreditPaymentEvent extends Obligation {
   o MonetaryAmount amount
   o String description
 }

--- a/src/servicelevelagreement/package.json
+++ b/src/servicelevelagreement/package.json
@@ -1,7 +1,7 @@
 {
     "name": "servicelevelagreement",
     "displayName": "Service Level Agreement",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A service level agreement that gives invoice credit based on service availability.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/servicelevelagreement/sample.json
+++ b/src/servicelevelagreement/sample.json
@@ -10,5 +10,5 @@
   "serviceProvider": "Service Provider",
   "serviceConsumer": "Service Consumer",
   "$identifier": "54e49d2c-309f-4cd5-adfe-3ee6b2fca66a",
-  "clauseId": "54e49d2c-309f-4cd5-adfe-3ee6b2fca66a"
+  "contractId": "54e49d2c-309f-4cd5-adfe-3ee6b2fca66a"
 }

--- a/src/supplyagreement-perishable-goods/model/model.cto
+++ b/src/supplyagreement-perishable-goods/model/model.cto
@@ -5,8 +5,8 @@
  */
 namespace org.accordproject.supplyagreementperishablegoods@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
-import org.accordproject.runtime@0.2.0.{Request,Response} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.runtime@0.2.0.{Request,Response,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
 /**
@@ -44,9 +44,9 @@ concept Shipment {
 }
 
 /**
- * Payment obligation event emitted when goods are received
+ * Payment obligation event emitted extends Obligation when goods are received
  */
-event PaymentObligationEvent {
+event PaymentObligationEvent extends Obligation {
   o String grower
   o String importer
   o MonetaryAmount totalPrice
@@ -74,7 +74,7 @@ transaction PriceCalculation extends Response {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o DateTime dueDate
   o String grower
   o String importer

--- a/src/supplyagreement-perishable-goods/package.json
+++ b/src/supplyagreement-perishable-goods/package.json
@@ -1,7 +1,7 @@
 {
     "name": "supplyagreement-perishable-goods",
     "displayName": "Supply Agreement Perishable Goods",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "This supply agreement specifies penalties if the transport conditions (temperature and humidity) for a package are breached.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/supplyagreement-perishable-goods/sample.json
+++ b/src/supplyagreement-perishable-goods/sample.json
@@ -21,5 +21,5 @@
   "maxHumidity": 90,
   "penaltyFactor": 0.2,
   "$identifier": "04661b9e-39fc-40dc-a85f-497c0defb9e9",
-  "clauseId": "04661b9e-39fc-40dc-a85f-497c0defb9e9"
+  "contractId": "04661b9e-39fc-40dc-a85f-497c0defb9e9"
 }

--- a/src/supplyagreement/model/model.cto
+++ b/src/supplyagreement/model/model.cto
@@ -1,6 +1,6 @@
 namespace org.accordproject.supplyagreement@0.2.0
 
-import org.accordproject.contract@0.2.0.Clause from https://models.accordproject.org/accordproject/contract@0.2.0.cto
+import org.accordproject.contract@0.2.0.Contract from https://models.accordproject.org/accordproject/contract@0.2.0.cto
 import org.accordproject.runtime@0.2.0.{Request,Response,State,Obligation} from https://models.accordproject.org/accordproject/runtime@0.2.0.cto
 import org.accordproject.money@0.3.0.MonetaryAmount from https://models.accordproject.org/money@0.3.0.cto
 
@@ -109,7 +109,7 @@ transaction PaymentResponse extends Response {
  * The template model
  */
 @template
-asset TemplateModel extends Clause {
+asset TemplateModel extends Contract {
   o DateTime effectiveDate
   o String supplier
   o String buyer

--- a/src/supplyagreement/package.json
+++ b/src/supplyagreement/package.json
@@ -1,7 +1,7 @@
 {
     "name": "supplyagreement",
     "displayName": "Supply Agreement",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A sample supply agreement.",
     "author": "Accord Project",
     "license": "Apache-2.0",

--- a/src/supplyagreement/sample.json
+++ b/src/supplyagreement/sample.json
@@ -21,5 +21,5 @@
   "governingState": "NY",
   "venueState": "NY",
   "$identifier": "be63697f-8672-4047-a02a-8b38dd7be146",
-  "clauseId": "be63697f-8672-4047-a02a-8b38dd7be146"
+  "contractId": "be63697f-8672-4047-a02a-8b38dd7be146"
 }


### PR DESCRIPTION
## Description
 This pr  addresses the model-level declaration gap described in the issue (https://github.com/accordproject/template-engine/issues/170)  for the related discussion on extending `Obligation` across template events.)

## Changes Made

- Updated the events to extend `Obligation`  in the template `model.cto` files.
- Updated template events to extend `org.accordproject.cicero.runtime.Obligation`, so the required `contract` back-reference is properly declared and inherited.
- Added a `contract` field to the relevant template declarations in the template `model.cto` files.


## Related Issues

Fixes https://github.com/accordproject/template-engine/issues/170

@mttrbrts 